### PR TITLE
AB#97101 What Is Your Role Page - use page name instead of page title

### DIFF
--- a/specification/ApplyToBecomeAnAcademy/01 Start Feature/05 What Is Your Role Page.md
+++ b/specification/ApplyToBecomeAnAcademy/01 Start Feature/05 What Is Your Role Page.md
@@ -8,15 +8,15 @@ https://www.figma.com/file/xqCVptyOcxauUXNum87EBG/A2B-v2.0?node-id=21%3A1770
 ### Scenario 2: Hyperlink (Back to start)
 
 GIVEN I am viewing the What Is Your Role Page  
-WHEN I click on the 'Back' hyperlink within the content  
+WHEN I click on the 'Back' hyperlink  
 THEN I am redirected back to the [**What Are You Applying To Do** page](04%20What%20Are%20You%20Applying%20To%20Do%20Page.md)
 
 
 ### Scenario 3: Radio Buttons (NOT Selected an Option - Validation Text)
 
 GIVEN I am viewing the What Is Your Role Page  
-WHEN I don't select one of the relevant radio buttons for what type of role I hold  
-AND I click on the 'Save and continue' CTA on the page  
+WHEN I don't select one of the radio buttons for what type of role I hold  
+AND I click on the 'Save and continue' CTA  
 THEN I am presented with an error message on the screen as per the Figma element  
 https://www.figma.com/file/xqCVptyOcxauUXNum87EBG/A2B-v2.0?node-id=939%3A7567
 
@@ -26,7 +26,7 @@ https://www.figma.com/file/xqCVptyOcxauUXNum87EBG/A2B-v2.0?node-id=939%3A7567
 GIVEN I am viewing the What Is Your Role Page  
 WHEN I select 'Something else' for what type of role I hold  
 AND I don't fill in the text box to state the name of my role  
-AND I click on the 'Save and continue' CTA on the page  
+AND I click on the 'Save and continue' CTA  
 THEN I am presented with an error message on the screen as per the Figma element  
 https://www.figma.com/file/xqCVptyOcxauUXNum87EBG/A2B-v2.0?node-id=938%3A7357
 
@@ -35,7 +35,7 @@ https://www.figma.com/file/xqCVptyOcxauUXNum87EBG/A2B-v2.0?node-id=938%3A7357
 
 GIVEN I am viewing the What Is Your Role Page  
 WHEN I select one of the two radio buttons  
-AND I click on the 'Save and continue' CTA on the page  
+AND I click on the 'Save and continue' CTA  
 THEN I am directed to the [**Application Overview** page](06%20Application%20Overview.md)
 
 
@@ -44,7 +44,7 @@ THEN I am directed to the [**Application Overview** page](06%20Application%20Ove
 GIVEN I am viewing the What Is Your Role Page  
 WHEN I select 'Something else' for what type of role I hold  
 AND I am fill in the text box to state the name of my role  
-AND I click on the 'Save and continue' CTA on the page  
+AND I click on the 'Save and continue' CTA  
 THEN I am directed to the [**Application Overview** page](06%20Application%20Overview.md)
 
 

--- a/specification/ApplyToBecomeAnAcademy/01 Start Feature/05 What Is Your Role Page.md
+++ b/specification/ApplyToBecomeAnAcademy/01 Start Feature/05 What Is Your Role Page.md
@@ -31,10 +31,10 @@ THEN I am presented with an error message on the screen as per the Figma element
 https://www.figma.com/file/xqCVptyOcxauUXNum87EBG/A2B-v2.0?node-id=938%3A7357
 
 
-### Scenario 5: Radio Buttons (The chair of the school’s governors OR A headteacher acting on their behalf option)
+### Scenario 5: Radio Buttons (The chair of the school’s governors OR A headteacher acting on their behalf)
 
 GIVEN I am viewing the What Is Your Role Page  
-AND I have selected one of the two radio buttons  
+AND I have selected 'The chair of the school’s governors' OR 'A headteacher acting on their behalf'  
 WHEN I click on the 'Save and continue' CTA  
 THEN I am directed to the [**Application Overview** page](06%20Application%20Overview.md)
 

--- a/specification/ApplyToBecomeAnAcademy/01 Start Feature/05 What Is Your Role Page.md
+++ b/specification/ApplyToBecomeAnAcademy/01 Start Feature/05 What Is Your Role Page.md
@@ -15,8 +15,8 @@ THEN I am redirected back to the [**What Are You Applying To Do** page](04%20Wha
 ### Scenario 3: Radio Buttons (NOT Selected an Option - Validation Text)
 
 GIVEN I am viewing the What Is Your Role Page  
-WHEN I don't select one of the radio buttons for what type of role I hold  
-AND I click on the 'Save and continue' CTA  
+AND I haven't selected one of the radio buttons for what type of role I hold  
+WHEN I click on the 'Save and continue' CTA  
 THEN I am presented with an error message on the screen as per the Figma element  
 https://www.figma.com/file/xqCVptyOcxauUXNum87EBG/A2B-v2.0?node-id=939%3A7567
 
@@ -24,9 +24,9 @@ https://www.figma.com/file/xqCVptyOcxauUXNum87EBG/A2B-v2.0?node-id=939%3A7567
 ### Scenario 4: Radio Button (Something else option - NO Text inputted  - Validation Text)
 
 GIVEN I am viewing the What Is Your Role Page  
-WHEN I select 'Something else' for what type of role I hold  
-AND I don't fill in the text box to state the name of my role  
-AND I click on the 'Save and continue' CTA  
+AND I have selected 'Something else' for what type of role I hold  
+AND I haven't filled in the text box to state the name of my role  
+WHEN I click on the 'Save and continue' CTA  
 THEN I am presented with an error message on the screen as per the Figma element  
 https://www.figma.com/file/xqCVptyOcxauUXNum87EBG/A2B-v2.0?node-id=938%3A7357
 
@@ -34,17 +34,17 @@ https://www.figma.com/file/xqCVptyOcxauUXNum87EBG/A2B-v2.0?node-id=938%3A7357
 ### Scenario 5: Radio Buttons (The chair of the school’s governors OR A headteacher acting on their behalf option)
 
 GIVEN I am viewing the What Is Your Role Page  
-WHEN I select one of the two radio buttons  
-AND I click on the 'Save and continue' CTA  
+AND I have selected one of the two radio buttons  
+WHEN I click on the 'Save and continue' CTA  
 THEN I am directed to the [**Application Overview** page](06%20Application%20Overview.md)
 
 
 ### Scenario 6: Radio Button (Something else option)
 
 GIVEN I am viewing the What Is Your Role Page  
-WHEN I select 'Something else' for what type of role I hold  
-AND I am fill in the text box to state the name of my role  
-AND I click on the 'Save and continue' CTA  
+AND I have selected 'Something else' for what type of role I hold  
+AND I have filled in the text box to state the name of my role  
+WHEN I click on the 'Save and continue' CTA  
 THEN I am directed to the [**Application Overview** page](06%20Application%20Overview.md)
 
 

--- a/specification/ApplyToBecomeAnAcademy/01 Start Feature/05 What Is Your Role Page.md
+++ b/specification/ApplyToBecomeAnAcademy/01 Start Feature/05 What Is Your Role Page.md
@@ -1,20 +1,20 @@
-### Scenario 1: Design and Content of What is your role Page
+### Scenario 1: Design and Content of What Is Your Role Page
 
-GIVEN I am viewing the 'What is your role' page  
+GIVEN I am viewing the What Is Your Role Page  
 THEN the page looks and reads as per the Figma element  
 https://www.figma.com/file/xqCVptyOcxauUXNum87EBG/A2B-v2.0?node-id=21%3A1770
 
 
 ### Scenario 2: Hyperlink (Back to start)
 
-GIVEN I am viewing the 'What is your role' page  
+GIVEN I am viewing the What Is Your Role Page  
 WHEN I click on the 'Back' hyperlink within the content  
 THEN I am redirected back to the [**What Are You Applying To Do** page](04%20What%20Are%20You%20Applying%20To%20Do%20Page.md)
 
 
 ### Scenario 3: Radio Buttons (NOT Selected an Option - Validation Text)
 
-GIVEN I am viewing the 'What is your role' page  
+GIVEN I am viewing the What Is Your Role Page  
 WHEN I don't select one of the relevant radio buttons for what type of role I hold  
 AND I click on the 'Save and continue' CTA on the page  
 THEN I am presented with an error message on the screen as per the Figma element  
@@ -23,7 +23,7 @@ https://www.figma.com/file/xqCVptyOcxauUXNum87EBG/A2B-v2.0?node-id=939%3A7567
 
 ### Scenario 4: Radio Button (Something else option - NO Text inputted  - Validation Text)
 
-GIVEN I am viewing the 'What is your role' page  
+GIVEN I am viewing the What Is Your Role Page  
 WHEN I select 'Something else' for what type of role I hold  
 AND I don't fill in the text box to state the name of my role  
 AND I click on the 'Save and continue' CTA on the page  
@@ -33,7 +33,7 @@ https://www.figma.com/file/xqCVptyOcxauUXNum87EBG/A2B-v2.0?node-id=938%3A7357
 
 ### Scenario 5: Radio Buttons (The chair of the school’s governors OR A headteacher acting on their behalf option)
 
-GIVEN I am viewing the 'What is your role' page  
+GIVEN I am viewing the What Is Your Role Page  
 WHEN I select one of the two radio buttons  
 AND I click on the 'Save and continue' CTA on the page  
 THEN I am directed to the [**Application Overview** page](06%20Application%20Overview.md)
@@ -41,7 +41,7 @@ THEN I am directed to the [**Application Overview** page](06%20Application%20Ove
 
 ### Scenario 6: Radio Button (Something else option)
 
-GIVEN I am viewing the 'What is your role' page  
+GIVEN I am viewing the What Is Your Role Page  
 WHEN I select 'Something else' for what type of role I hold  
 AND I am fill in the text box to state the name of my role  
 AND I click on the 'Save and continue' CTA on the page  
@@ -50,6 +50,6 @@ THEN I am directed to the [**Application Overview** page](06%20Application%20Ove
 
 ### Scenario 7: Hyperlink (Cancel and return to your applications)
 
-GIVEN I am viewing the 'What is your role' page  
+GIVEN I am viewing the What Is Your Role Page  
 WHEN I click on the 'Cancel and return to your applications' hyperlink within the content  
 THEN I am redirected to the [**Your applications list** page](03%20Your%20applications%20list%20Page.md)


### PR DESCRIPTION
A few edits to these gherkins:

* use page name instead of page title
* deleted a few words that don't add any clarity
* eliminated ANDs in the WHEN clauses