### PR TITLE
AB#92475 Page Header & Footer - add linked static pages with page titles

### DIFF
--- a/Dfe.Academies.External.Web/Pages/Accessibility.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Accessibility.cshtml
@@ -1,0 +1,54 @@
+﻿@page
+@{
+	ViewData["Title"] = "Accessibility statement";
+}
+
+<div class="govuk-grid-column-two-thirds">
+
+	<h1 class="govuk-heading-l">Accessibility statement</h1>
+	<p>
+		This statement was prepared on 9 October 2019. It was last updated on 11 October 2019.
+	</p>
+	<p>
+		We have developed the ‘apply to become an academy’ service to be accessible and easy to use for everyone. We have aimed to achieve and maintain to the
+		<a href="https://www.w3.org/TR/WCAG21/" target="_blank" class="govuk-link--no-visited-state">
+			Worldwide Web Consortium’s (W3C) Web Content Accessibility Guidelines 2.1 (WCAG.2.1)
+		</a> Level AA standard.
+	</p>
+	<p>
+		The Department for Education is committed to making its digital services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+	</p>
+	<p>
+		We have tested the service cross multiple browsers and devices –
+		<a href="https://updatemybrowser.org/" target="_blank" class="govuk-link--no-visited-state">
+			check you’ve installed the latest updates to your browser
+		</a> to get the best user experience.
+	</p>
+	<p>
+		DfE’s accessibility lead fully accessibility tested the service in September 2019. They used the software Jaws 2018, SuperNova v18, Zoomtext 2019 and Dragon NaturallySpeaking V15.4.
+	</p>
+
+	<h1 class="govuk-heading-l">Dragon NaturallySpeaking</h1>
+	<p>
+		We have found that Dragon users will need to employ the dictation box when filling in the text boxes into form fields to use the application effectively. Users should also be familiar with MouseGrid.
+	</p>
+
+	<h1 class="govuk-heading-l">Reporting accessibility problems</h1>
+	<p>
+		If you encounter an issue or if you think we’re not meeting accessibility requirements, please email
+		<a href="mailto:applytoconvert.support@education.gov.uk" class="govuk-link--no-visited-state">applytoconvert.support@education.gov.uk</a>
+		with 'Accessibility issues' in the subject line of the email.
+	</p>
+
+	<h1 class="govuk-heading-l">Enforcement procedure</h1>
+	<p>
+		The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
+		If you’re not happy with how we respond to your complaint, <a href="https://www.equalityadvisoryservice.com/" target="_blank" class="govuk-link--no-visited-state">contact the Equality Advisory and Support Service (EASS)</a>.
+	</p>
+
+	<h1 class="govuk-heading-l">Contacting us by phone</h1>
+	<p>
+		If you are having problems using this service and you need help, call the Department for Education on 0370 000 2288.
+	</p>
+
+</div>

--- a/Dfe.Academies.External.Web/Pages/Cookies.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Cookies.cshtml
@@ -1,0 +1,7 @@
+﻿@page
+@model Dfe.Academies.External.Web.Pages.CookiesModel
+@{
+	ViewData["Title"] = "Cookies";
+}
+
+    <p style="background-color: yellow;">Cookie content to go here</p>

--- a/Dfe.Academies.External.Web/Pages/Cookies.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Cookies.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Dfe.Academies.External.Web.Pages
+{
+    public class CookiesModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/Dfe.Academies.External.Web/Pages/Index.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Index.cshtml
@@ -1,7 +1,7 @@
 ﻿@page
 @model IndexModel
 @{
-    ViewData["Title"] = "Apply to become an academy";
+    ViewData["Title"] = "Home";
 }
 
 	<div class="govuk-grid-column-two-thirds">

--- a/Dfe.Academies.External.Web/Pages/Shared/_Footer.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Shared/_Footer.cshtml
@@ -5,13 +5,13 @@
 				<h2 class="govuk-visually-hidden">Support links</h2>
 				<ul class="govuk-footer__inline-list">
 					<li class="govuk-footer__inline-list-item">
-						<a class="govuk-footer__link" href="/Pages/Accessibility">Accessibility statement</a>
+						<a asp-page="/Accessibility" class="govuk-footer__link">Accessibility statement</a>
 					</li>
 					<li class="govuk-footer__inline-list-item">
-						<a class="govuk-footer__link" asp-controller="Cookies" asp-action="Index">Cookie policy</a>
+						<a asp-page="Cookies" class="govuk-footer__link">Cookie policy</a>
 					</li>
 					<li class="govuk-footer__inline-list-item">
-						<a class="govuk-footer__link" href="/Pages/Terms">Terms and Conditions</a>
+						<a asp-page="Terms" class="govuk-footer__link">Terms and Conditions</a>
 					</li>
 				</ul>
 

--- a/Dfe.Academies.External.Web/Pages/Shared/_Layout.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Shared/_Layout.cshtml
@@ -28,7 +28,7 @@
 	}
 
 	<meta charset="utf-8">
-	<title>A2C - GOV.UK</title>
+	<title>@ViewData["Title"] &ndash; Apply to become an academy</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 	<meta name="theme-color" content="blue"/>
 

--- a/Dfe.Academies.External.Web/Pages/Terms.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Terms.cshtml
@@ -1,0 +1,114 @@
+﻿@page
+@{
+	ViewData["Title"] = "Terms and Conditions";
+}
+
+<div class="govuk-grid-column-two-thirds">
+	<h1 class="govuk-heading-xl">Terms and Conditions</h1>
+	<h2 class="govuk-heading-l">All Users</h2>
+
+	<h3 class="govuk-heading-m">Using the Apply to become an Academy service</h3>
+	<p>
+		Please read these Terms of Use (“General Terms”) carefully before using this service (the “Service”).
+	</p>
+	<p>
+		This Service is maintained for your personal use and viewing. Access and use by you of this Service constitutes your acceptance of these General Terms.
+		This takes effect from the date on which you first use this website. If you do not agree to these terms, you must not use this website.
+	</p>
+	<p>
+		If we change these General Terms we will post the revised document here with an updated effective date.
+		If we make significant changes to these terms, we may notify you by other means such as sending an email or posting a notice on our home page.
+	</p>
+
+	<h3 class="govuk-heading-m">Information About Us</h3>
+	<p>
+		This Service is operated by the Department for Education (“we”, “our”, or “us”).
+		We are a central government department and have our registered office at Sanctuary Buildings, 20 Great Smith Street, London, SW1P 3BT.
+	</p>
+	<p>
+		You can contact us using the following email address:
+		<a href="mailto: applytoconvert.support@education.gov.uk" class="govuk-link">applytoconvert.support@education.gov.uk</a>
+	</p>
+
+	<h3 class="govuk-heading-m">Access to the Service</h3>
+	<p>
+		We shall not be liable if for any reason the Service is unavailable at any time or for any period.
+		From time to time, we may restrict access to all or some parts of the Service to users who have registered with us.
+	</p>
+	<p>
+		If you choose, or are provided with, a user identification code, password or any other piece of information as part of our security procedures,
+		you must treat such information as confidential, and you must not disclose it to any third party.
+	</p>
+	<p>
+		We reserve the right to restrict or deny you access to all or some part of the Service if in our opinion, you have failed to comply with these General Terms.
+	</p>
+
+	<h3 class="govuk-heading-m">Hyperlinking to the Service</h3>
+	<p>
+		We do not object to you linking directly to the Service's home pages and you do not need to ask permission to do so.
+		However, we do not permit our pages to be loaded into frames on your site. The Service pages must be displayed in the user’s entire browser window.
+	</p>
+
+	<h3 class="govuk-heading-m">Third Party Content and hyperlinking from the Service</h3>
+	<p>
+		Where the Service contains links to other sites and resources, we are not liable or responsible for the content or reliability of those
+		websites and resources and do not necessarily endorse the views expressed within them.
+	</p>
+	<p>
+		We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no control over the availability of other sites.
+	</p>
+
+	<h3 class="govuk-heading-m">Virus protection</h3>
+	<p>
+		We make every effort to check and test material at all stages of production.
+		It is always wise for you to run an anti-virus program on all material downloaded from the Internet as we do not guarantee our service will be secure or free from bugs or viruses.
+		We cannot accept any responsibility for any loss, disruption or damage to your data or your computer system which may occur whilst using material derived from this website.
+	</p>
+	<p>
+		You must not misuse our service by knowingly introducing viruses, trojans, worms, logic bombs or other material that is malicious or technologically harmful.
+		You must not attempt to gain unauthorised access to our service, the server on which our service is stored or any server, computer or database connected to our service.
+		You must not attack our site via a denial-of-service attack or a distributed denial-of service attack. Each of these acts is a criminal offence.
+		We will report any such offence to the relevant law enforcement authorities and co-operate with them to determine your identity.
+	</p>
+
+	<h3 class="govuk-heading-m">Disclaimer and Liability</h3>
+	<p>
+		The content of this Service includes both content created by us (included but not limited to content that helps you use the Service) and third-party content. We do not:
+	</p>
+	<ul class="govuk-list govuk-list--bullet">
+		<li>endorse third-party content</li>
+		<li>vouch for its accuracy</li>
+		<li>guarantee that the views, instructions and/or assertions expressed in it are our own</li>
+	</ul>
+	<p>
+		The content we create for the Service is not advice. You should verify any information on the Service yourself and use your own judgement before doing or
+		not doing anything on the basis of the content.
+	</p>
+	<p>
+		Unless expressly stated in writing by us, the Service and material relating to government information, products and services (or to third party information, products and services),
+		is provided ‘as is’, without any representation or endorsement made and without warranty of any kind whether express or implied,
+		including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.
+	</p>
+	<p>
+		We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error free, that defects will be corrected,
+		or that this site or the server that makes it available are free of viruses or represent the full functionality, accuracy, reliability of the materials.
+	</p>
+	<p>
+		In no event will we be liable for:
+	</p>
+	<ul class="govuk-list govuk-list--bullet">
+		<li>any action you may take as a result of relying on any information/materials provided on the Service or for any loss or damage suffered by you as a result of you taking such action including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from or in connection with the use of the Service </li>
+		<li>any dealings you have with third parties (e.g. other users or advertisers) that take place using or facilitated by the Service </li>
+	</ul>
+
+	<h3 class="govuk-heading-m">Validity of these General Terms</h3>
+	<p>
+		If any of these terms and conditions are held to be invalid, unenforceable or illegal for any reason, the remaining terms and conditions will still apply.
+	</p>
+
+	<h3 class="govuk-heading-m">Applicable Law and Jurisdiction</h3>
+	<p>
+		These General Terms are governed by the laws of England and Wales. Any dispute arising under these General Terms will be subject to the exclusive jurisdiction of the courts of England and Wales.
+	</p>
+
+</div>

--- a/Dfe.Academies.External.Web/Program.cs
+++ b/Dfe.Academies.External.Web/Program.cs
@@ -13,6 +13,9 @@ builder.Services
 		options.Conventions
 			.AuthorizeFolder("/", "AcademiesExternalPolicy")
 			.AllowAnonymousToPage("/Index")
+			.AllowAnonymousToPage("/Accessibility")
+			.AllowAnonymousToPage("/Cookies")
+			.AllowAnonymousToPage("/Terms")
 			.AllowAnonymousToPage("/WhatYouWillNeed");
 	})
 	.AddRazorPagesOptions(options =>


### PR DESCRIPTION
Added pages:

* Accessibility (copied from current A2B External)
* Cookies (blank for now)
* Terms (copied from current A2B External)