### PR TITLE
Add default Academies API config

### DIFF
--- a/Dfe.Academies.External.Web/appsettings.json
+++ b/Dfe.Academies.External.Web/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "academies": {
+    "api_endpoint": "TBC",
+    "api_key": "TBC"
+  }
 }


### PR DESCRIPTION
Adding default config to the appsettings.json so that the dev environment doesn't fail