### PR TITLE
Remove DfE Sign-in urls from appsettings.Development.json

### DIFF
--- a/Dfe.Academies.External.Web/appsettings.Development.json
+++ b/Dfe.Academies.External.Web/appsettings.Development.json
@@ -6,12 +6,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AppSettings": {
-    "DFESignAPIURL": "https://test-interactions.signin.education.gov.uk/",
-    "DFESignInApplyToConvertServiceID": "03BC03C1-8661-4FCD-8EA0-70EE1B9585C8",
-    "DFESignInApplyToConvertOrganisationID": "09158CF5-A701-47E8-BDCD-4EA201B024A3"
-  },
   "academies": {
-    "api_endpoint": "https://webapp-t1dv-sip-a2c.azurewebsites.net/",
+    "api_endpoint": "https://webapp-t1dv-sip-a2c.azurewebsites.net/"
   }
 }


### PR DESCRIPTION
These are for Authorization checks on organisation or service membership that we don't do