### PR TITLE
remove contributor properties from application model - bring in line with API

### DIFF
--- a/Dfe.Academies.External.Web.UnitTest/Factories/ConversionApplicationTestDataFactory.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Factories/ConversionApplicationTestDataFactory.cs
@@ -1,4 +1,5 @@
-﻿using AutoFixture;
+﻿using System.Collections.Generic;
+using AutoFixture;
 using Dfe.Academies.External.Web.Enums;
 using Dfe.Academies.External.Web.Models;
 
@@ -28,8 +29,10 @@ internal static class ConversionApplicationTestDataFactory
             ApplicationId = int.MaxValue,
             ApplicationType = ApplicationTypes.FormNewMat,
             Application = Fixture.Create<string>(),
-            SchoolRole = SchoolRoles.Other,
-            OtherRoleNotListed = Fixture.Create<string>()
+			Contributors = new()
+			{
+				new ConversionApplicationContributor(Fixture.Create<string>(), Fixture.Create<string>(), SchoolRoles.Other, Fixture.Create<string>())
+			}
         };
     }
 
@@ -41,7 +44,10 @@ internal static class ConversionApplicationTestDataFactory
             ApplicationId = int.MaxValue,
             ApplicationType = ApplicationTypes.FormNewMat,
             Application = Fixture.Create<string>(),
-            SchoolRole = SchoolRoles.Chair
-        };
+            Contributors = new()
+            {
+	            new ConversionApplicationContributor(Fixture.Create<string>(), Fixture.Create<string>(), SchoolRoles.Chair, null)
+	        }
+		};
     }
 }

--- a/Dfe.Academies.External.Web/Models/ConversionApplication.cs
+++ b/Dfe.Academies.External.Web/Models/ConversionApplication.cs
@@ -20,11 +20,6 @@ public class ConversionApplication
     
     public List<ConversionApplicationContributor> Contributors { get; set; } = new();
 
-	// TODO MR:- below needs ripping out and will be a Contributor within the List<Contributor>
-	public SchoolRoles? SchoolRole { get; set; }
-
-    public string? OtherRoleNotListed { get; set; }
-
     public int ConversionStatus { get; set; }
 
     public NewTrust? FormATrust { get; set; }

--- a/Dfe.Academies.External.Web/Pages/WhatIsYourRole.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/WhatIsYourRole.cshtml.cs
@@ -1,4 +1,4 @@
-using Dfe.Academies.External.Web.Attributes;
+﻿using Dfe.Academies.External.Web.Attributes;
 using Dfe.Academies.External.Web.Enums;
 using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
@@ -60,8 +60,7 @@ public class WhatIsYourRoleModel : BasePageModel
     {
         if (!ModelState.IsValid)
         {
-            // error messages component consumes ViewData["Errors"]
-            PopulateValidationMessages();
+	        PopulateValidationMessages();
             return Page();
         }
 
@@ -77,9 +76,9 @@ public class WhatIsYourRoleModel : BasePageModel
 	        //// grab draft application from temp= null
 	        var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
-
-            draftConversionApplication.SchoolRole = SchoolRole;
-            draftConversionApplication.OtherRoleNotListed = OtherRoleNotListed;
+			// TODO MR:- get firstname / surname / email from Auth details?????
+	        var creationContributor = new ConversionApplicationContributor("", "", SchoolRole, OtherRoleNotListed);
+	        draftConversionApplication.Contributors.Add(creationContributor);
 
             await _academisationCreationService.UpdateDraftApplication(draftConversionApplication);
 
@@ -99,7 +98,8 @@ public class WhatIsYourRoleModel : BasePageModel
     {
         ViewData["Errors"] = ConvertModelStateToDictionary();
 
-        if (!ModelState.IsValid)
+        // V2 figma has different error messages hence why code below exists !!
+		if (!ModelState.IsValid)
         {
             if (ModelState.Keys.Contains("SchoolRole") && !this.ValidationErrorMessagesViewModel.ValidationErrorMessages.ContainsKey("SchoolRole"))
             {


### PR DESCRIPTION
remove contributor properties from application model to convert to ConversionApplicationContributor object as per API specification

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Role properties no longer exist at application model level (only put here temporarily while dev'ing UI). So moved setting of these properties into the ConversionApplicationContributor object as per API specification

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. Run Unit Tests
2. Run the application, go through wizard to ensure everything working as expected i.e. when you input role / other role ensure app doesn't blow up

## Prerequisites
n/a
