### PR TITLE
104118 wire up add school to application

### DIFF
--- a/Dfe.Academies.External.Web.UnitTest/ExampleJsonResponses/putApplicationSchoolOnly.json
+++ b/Dfe.Academies.External.Web.UnitTest/ExampleJsonResponses/putApplicationSchoolOnly.json
@@ -1,0 +1,58 @@
+{
+	"applicationId": 2,
+	"applicationType": "JoinAMat",
+	"applicationStatus": "InProgress",
+	"contributors": [
+		{
+			"contributorId": 2,
+			"firstName": "bob",
+			"lastName": "bob",
+			"emailAddress": "bob@test.com",
+			"role": "Other",
+			"otherRoleName": "bob"
+		}
+	],
+	"schools": [
+		{
+			"id": 0,
+			"urn": 123332,
+			"schoolName": "Frank Wise School",
+			"landAndBuildings": {
+				"ownerExplained": "",
+				"worksPlanned": false,
+				"worksPlannedDate": null,
+				"worksPlannedExplained": "",
+				"facilitiesShared": false,
+				"facilitiesSharedExplained": "",
+				"grants": false,
+				"grantsAwardingBodies": "",
+				"partOfPfiScheme": false,
+				"partOfPfiSchemeType": "",
+				"partOfPrioritySchoolsBuildingProgramme": false,
+				"partOfBuildingSchoolsForFutureProgramme": false
+			},
+			"schoolConversionContactHeadName": "",
+			"schoolConversionContactHeadEmail": null,
+			"schoolConversionContactHeadTel": "",
+			"schoolConversionContactChairName": "",
+			"schoolConversionContactChairEmail": null,
+			"schoolConversionContactChairTel": "",
+			"schoolConversionContactRole": "",
+			"schoolConversionMainContactOtherName": "",
+			"schoolConversionMainContactOtherEmail": null,
+			"schoolConversionMainContactOtherTelephone": "",
+			"schoolConversionMainContactOtherRole": "",
+			"schoolConversionApproverContactName": "",
+			"schoolConversionApproverContactEmail": null,
+			"schoolConversionTargetDate": null,
+			"schoolConversionTargetDateExplained": "",
+			"proposedNewSchoolName": "",
+			"applicationJoinTrustReason": "",
+			"projectedPupilNumbersYear1": 0,
+			"projectedPupilNumbersYear2": 0,
+			"projectedPupilNumbersYear3": 0,
+			"schoolCapacityAssumptions": "",
+			"schoolCapacityPublishedAdmissionsNumber": 0
+		}
+	]
+}

--- a/Dfe.Academies.External.Web.UnitTest/Services/ConversionApplicationCreationServiceTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Services/ConversionApplicationCreationServiceTests.cs
@@ -27,13 +27,13 @@ internal sealed class ConversionApplicationCreationServiceTests
 		string expectedJson = await File.ReadAllTextAsync(fullFilePath);
 		var conversionApplication = ConversionApplicationTestDataFactory.BuildNewConversionApplicationNoRoles();
 
-		var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.BadRequest, expectedJson);
-        var mockLogger = new Mock<ILogger<ConversionApplicationCreationService>>();
+		var mockCreationHttpClientFactory = SetupMockHttpClientFactory(HttpStatusCode.BadRequest, expectedJson);
+        var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
         var mockConversionApplicationRetrievalService = new Mock<IConversionApplicationRetrievalService>();
 		
-		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object, 
-																							mockLogger.Object,
-																							mockConversionApplicationRetrievalService.Object);
+		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockCreationHttpClientFactory.Object,
+			mockLoggerCreationService.Object, 
+			mockConversionApplicationRetrievalService.Object);
 
 		// act / assert
 		var ex = Assert.ThrowsAsync<ArgumentException>(() => conversionApplicationCreationService.CreateNewApplication(conversionApplication));
@@ -50,12 +50,12 @@ internal sealed class ConversionApplicationCreationServiceTests
 		string expectedJson = await File.ReadAllTextAsync(fullFilePath);
 		var conversionApplication = ConversionApplicationTestDataFactory.BuildNewConversionApplicationWithOtherRole();
 
-		var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.Created, expectedJson);
-	    var mockLogger = new Mock<ILogger<ConversionApplicationCreationService>>();
+		var mockCreationHttpClientFactory = SetupMockHttpClientFactory(HttpStatusCode.Created, expectedJson);
+	    var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
 		var mockConversionApplicationRetrievalService = new Mock<IConversionApplicationRetrievalService>();
 
-		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object,
-			mockLogger.Object,
+		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockCreationHttpClientFactory.Object,
+			mockLoggerCreationService.Object,
 			mockConversionApplicationRetrievalService.Object);
 
 		// act
@@ -82,13 +82,14 @@ internal sealed class ConversionApplicationCreationServiceTests
         string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
         string expectedJson = await File.ReadAllTextAsync(fullFilePath);
 		
-		var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
-        var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
+		var mockCreationHttpClientFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, string.Empty);
+		var mockRetrievalHttpClientFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
+		var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
         var mockLoggerRetrievalService = new Mock<ILogger<ConversionApplicationRetrievalService>>();
-		var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockFactory.Object, mockLoggerRetrievalService.Object);
+		var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockRetrievalHttpClientFactory.Object, mockLoggerRetrievalService.Object);
 
 		// act
-		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object,
+		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockCreationHttpClientFactory.Object,
 			mockLoggerCreationService.Object,
 			mockConversionApplicationRetrievalService);
 
@@ -110,21 +111,19 @@ internal sealed class ConversionApplicationCreationServiceTests
 	    string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
 	    string expectedJson = await File.ReadAllTextAsync(fullFilePath);
 
-	    var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.InternalServerError, expectedJson);
-	    var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
+	    var mockCreationHttpClientFactory = SetupMockHttpClientFactory(HttpStatusCode.InternalServerError, string.Empty);
+	    var mockRetrievalHttpClientFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
+		var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
 	    var mockLoggerRetrievalService = new Mock<ILogger<ConversionApplicationRetrievalService>>();
-	    var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockFactory.Object, mockLoggerRetrievalService.Object);
+	    var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockRetrievalHttpClientFactory.Object, mockLoggerRetrievalService.Object);
 
 	    // act
-	    var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object,
+	    var conversionApplicationCreationService = new ConversionApplicationCreationService(mockCreationHttpClientFactory.Object,
 		    mockLoggerCreationService.Object,
 		    mockConversionApplicationRetrievalService);
 
 		// assert
-		var ex = Assert.ThrowsAsync<ArgumentException>(() => conversionApplicationCreationService.AddSchoolToApplication(applicationId, urn, schoolName));
-
-        // now we could test the exception itself
-        //Assert.That(ex.Message == "Blah");
+		Assert.ThrowsAsync<HttpRequestException>(() => conversionApplicationCreationService.AddSchoolToApplication(applicationId, urn, schoolName));
     }
 
     [Test]
@@ -137,13 +136,14 @@ internal sealed class ConversionApplicationCreationServiceTests
 	    string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
 	    string expectedJson = await File.ReadAllTextAsync(fullFilePath);
 
-	    var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
-	    var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
+	    var mockCreationHttpClientFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, string.Empty);
+	    var mockRetrievalHttpClientFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
+		var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
 	    var mockLoggerRetrievalService = new Mock<ILogger<ConversionApplicationRetrievalService>>();
-	    var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockFactory.Object, mockLoggerRetrievalService.Object);
+	    var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockRetrievalHttpClientFactory.Object, mockLoggerRetrievalService.Object);
 
 	    // act
-	    var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object,
+	    var conversionApplicationCreationService = new ConversionApplicationCreationService(mockCreationHttpClientFactory.Object,
 		    mockLoggerCreationService.Object,
 		    mockConversionApplicationRetrievalService);
 
@@ -168,13 +168,14 @@ internal sealed class ConversionApplicationCreationServiceTests
 		string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
 		string expectedJson = await File.ReadAllTextAsync(fullFilePath);
 
-		var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
+		var mockCreationHttpClientFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, string.Empty);
+		var mockRetrievalHttpClientFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
 		var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
 		var mockLoggerRetrievalService = new Mock<ILogger<ConversionApplicationRetrievalService>>();
-		var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockFactory.Object, mockLoggerRetrievalService.Object);
+		var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockRetrievalHttpClientFactory.Object, mockLoggerRetrievalService.Object);
 
 		// act
-		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object,
+		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockCreationHttpClientFactory.Object,
 			mockLoggerCreationService.Object,
 			mockConversionApplicationRetrievalService);
 
@@ -197,13 +198,14 @@ internal sealed class ConversionApplicationCreationServiceTests
 		string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
 		string expectedJson = await File.ReadAllTextAsync(fullFilePath);
 
-		var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.InternalServerError, expectedJson);
+		var mockCreationHttpClientFactory = SetupMockHttpClientFactory(HttpStatusCode.InternalServerError, string.Empty);
+		var mockRetrievalHttpClientFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
 		var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
 		var mockLoggerRetrievalService = new Mock<ILogger<ConversionApplicationRetrievalService>>();
-		var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockFactory.Object, mockLoggerRetrievalService.Object);
+		var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockRetrievalHttpClientFactory.Object, mockLoggerRetrievalService.Object);
 
 		// act
-		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object,
+		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockCreationHttpClientFactory.Object,
 			mockLoggerCreationService.Object,
 			mockConversionApplicationRetrievalService);
 

--- a/Dfe.Academies.External.Web.UnitTest/Services/ConversionApplicationCreationServiceTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Services/ConversionApplicationCreationServiceTests.cs
@@ -25,11 +25,15 @@ internal sealed class ConversionApplicationCreationServiceTests
 		// arrange
 		string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/createApplicationResponseInValid.json";
 		string expectedJson = await File.ReadAllTextAsync(fullFilePath);
+		var conversionApplication = ConversionApplicationTestDataFactory.BuildNewConversionApplicationNoRoles();
 
 		var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.BadRequest, expectedJson);
         var mockLogger = new Mock<ILogger<ConversionApplicationCreationService>>();
-        var conversionApplication = ConversionApplicationTestDataFactory.BuildNewConversionApplicationNoRoles();
-        var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object, mockLogger.Object);
+        var mockConversionApplicationRetrievalService = new Mock<IConversionApplicationRetrievalService>();
+		
+		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object, 
+																							mockLogger.Object,
+																							mockConversionApplicationRetrievalService.Object);
 
 		// act / assert
 		var ex = Assert.ThrowsAsync<ArgumentException>(() => conversionApplicationCreationService.CreateNewApplication(conversionApplication));
@@ -44,10 +48,15 @@ internal sealed class ConversionApplicationCreationServiceTests
 		// arrange
 		string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/createApplicationResponse.json";
 		string expectedJson = await File.ReadAllTextAsync(fullFilePath);
+		var conversionApplication = ConversionApplicationTestDataFactory.BuildNewConversionApplicationWithOtherRole();
+
 		var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.Created, expectedJson);
 	    var mockLogger = new Mock<ILogger<ConversionApplicationCreationService>>();
-	    var conversionApplication = ConversionApplicationTestDataFactory.BuildNewConversionApplicationWithOtherRole();
-	    var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object, mockLogger.Object);
+		var mockConversionApplicationRetrievalService = new Mock<IConversionApplicationRetrievalService>();
+
+		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object,
+			mockLogger.Object,
+			mockConversionApplicationRetrievalService.Object);
 
 		// act
 		var newApplication = await conversionApplicationCreationService.CreateNewApplication(conversionApplication);
@@ -59,6 +68,176 @@ internal sealed class ConversionApplicationCreationServiceTests
 
 	    Assert.AreNotEqual(newApplication.ApplicationId, 0);
     }
+
+	/// <summary>
+	/// call add school endpoint and mock HttpStatusCode.Created
+	/// </summary>
+	[Test]
+	public async Task AddSchoolToApplication___ApiReturns200___Ok()
+    {
+	    // arrange
+	    int applicationId = 1; // hard coded because has to be same as example JSON
+        int urn = Fixture.Create<int>();
+        string schoolName = Fixture.Create<string>();
+        string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
+        string expectedJson = await File.ReadAllTextAsync(fullFilePath);
+		
+		var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
+        var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
+        var mockLoggerRetrievalService = new Mock<ILogger<ConversionApplicationRetrievalService>>();
+		var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockFactory.Object, mockLoggerRetrievalService.Object);
+
+		// act
+		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object,
+			mockLoggerCreationService.Object,
+			mockConversionApplicationRetrievalService);
+
+	    // assert
+	    Assert.DoesNotThrowAsync(() => conversionApplicationCreationService.AddSchoolToApplication(applicationId, urn, schoolName));
+    }
+
+    /// <summary>
+    /// call add school endpoint and mock HttpStatusCode.InternalServerError
+    /// </summary>
+    [Test]
+    public async Task AddSchoolToApplication___ApiReturns500___InternalServerError()
+    {
+		// arrange
+		int applicationId = 1; // hard coded because has to be same as example JSON
+		int urn = Fixture.Create<int>();
+	    string schoolName = Fixture.Create<string>();
+
+	    string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
+	    string expectedJson = await File.ReadAllTextAsync(fullFilePath);
+
+	    var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.InternalServerError, expectedJson);
+	    var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
+	    var mockLoggerRetrievalService = new Mock<ILogger<ConversionApplicationRetrievalService>>();
+	    var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockFactory.Object, mockLoggerRetrievalService.Object);
+
+	    // act
+	    var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object,
+		    mockLoggerCreationService.Object,
+		    mockConversionApplicationRetrievalService);
+
+		// assert
+		var ex = Assert.ThrowsAsync<ArgumentException>(() => conversionApplicationCreationService.AddSchoolToApplication(applicationId, urn, schoolName));
+
+        // now we could test the exception itself
+        //Assert.That(ex.Message == "Blah");
+    }
+
+    [Test]
+    public async Task AddSchoolToApplication___InvalidApplicationId___ArgumentException()
+    {
+	    // arrange
+	    int applicationId = Fixture.Create<int>();
+	    int urn = Fixture.Create<int>();
+	    string schoolName = Fixture.Create<string>();
+	    string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
+	    string expectedJson = await File.ReadAllTextAsync(fullFilePath);
+
+	    var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
+	    var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
+	    var mockLoggerRetrievalService = new Mock<ILogger<ConversionApplicationRetrievalService>>();
+	    var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockFactory.Object, mockLoggerRetrievalService.Object);
+
+	    // act
+	    var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object,
+		    mockLoggerCreationService.Object,
+		    mockConversionApplicationRetrievalService);
+
+		// assert
+		var ex = Assert.ThrowsAsync<ArgumentException>(() => conversionApplicationCreationService.AddSchoolToApplication(applicationId, urn, schoolName));
+
+		// now we could test the exception itself
+		Assert.That(ex.Message == "Application not found");
+	}
+
+	/// <summary>
+	/// call endpoint and mock HttpStatusCode.Created
+	/// </summary>
+	//[Test]
+	public async Task ApplicationAddJoinTrustReasons___ApiReturns200___Ok()
+    {
+		// arrange
+		int applicationId = 2; // hard coded because has to be same as example JSON
+		int urn = Fixture.Create<int>();
+		string applicationAddJoinTrustReason = Fixture.Create<string>();
+
+		string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
+		string expectedJson = await File.ReadAllTextAsync(fullFilePath);
+
+		var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
+		var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
+		var mockLoggerRetrievalService = new Mock<ILogger<ConversionApplicationRetrievalService>>();
+		var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockFactory.Object, mockLoggerRetrievalService.Object);
+
+		// act
+		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object,
+			mockLoggerCreationService.Object,
+			mockConversionApplicationRetrievalService);
+
+		// assert
+		Assert.DoesNotThrowAsync(() => conversionApplicationCreationService.ApplicationAddJoinTrustReasons(applicationId, 
+																								applicationAddJoinTrustReason, urn));
+    }
+
+    /// <summary>
+    /// call endpoint and mock HttpStatusCode.InternalServerError
+    /// </summary>
+    //[Test]
+    public async Task ApplicationAddJoinTrustReasons___ApiReturns500___InternalServerError()
+    {
+		// arrange
+		int applicationId = 2; // hard coded because has to be same as example JSON
+		int urn = Fixture.Create<int>();
+		string applicationAddJoinTrustReason = Fixture.Create<string>();
+
+		string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
+		string expectedJson = await File.ReadAllTextAsync(fullFilePath);
+
+		var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.InternalServerError, expectedJson);
+		var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
+		var mockLoggerRetrievalService = new Mock<ILogger<ConversionApplicationRetrievalService>>();
+		var mockConversionApplicationRetrievalService = new ConversionApplicationRetrievalService(mockFactory.Object, mockLoggerRetrievalService.Object);
+
+		// act
+		var conversionApplicationCreationService = new ConversionApplicationCreationService(mockFactory.Object,
+			mockLoggerCreationService.Object,
+			mockConversionApplicationRetrievalService);
+
+		// assert
+		var ex = Assert.ThrowsAsync<HttpRequestException>(() => conversionApplicationCreationService.ApplicationAddJoinTrustReasons(applicationId, 
+																									applicationAddJoinTrustReason, urn));
+
+        // now we could test the exception itself
+        //Assert.That(ex.Message == "Blah");
+    }
+
+	// TODO MR:- ApplicationChangeSchoolNameAndReason - ApiReturns200___Ok()
+
+	// TODO MR:- ApplicationChangeSchoolNameAndReason - ApiReturns500___InternalServerError()
+
+	// TODO MR:- ApplicationSchoolTargetConversionDate - ApiReturns200___Ok()
+
+	// TODO MR:- ApplicationSchoolTargetConversionDate - ApiReturns500___InternalServerError()
+
+	// TODO MR:- ApplicationSchoolTargetConversionDate - ApiReturns200___Ok()
+
+	// TODO MR:- ApplicationSchoolTargetConversionDate - ApiReturns500___InternalServerError()
+
+	// TODO MR:- ApplicationSchoolFuturePupilNumbers - ApiReturns200___Ok()
+
+	// TODO MR:- ApplicationSchoolFuturePupilNumbers - ApiReturns500___InternalServerError()
+
+	// TODO MR:- ApplicationSchoolContacts - ApiReturns200___Ok()
+
+	// TODO MR:- ApplicationSchoolContacts - ApiReturns500___InternalServerError()
+
+	// TODO MR:- ApplicationSchoolLandAndBuildings - ApiReturns200___Ok()
+
+	// TODO MR:- ApplicationSchoolLandAndBuildings - ApiReturns500___InternalServerError()
 
 	//public async Task UpdateDraftApplication___OtherRole___Success()
 	//{
@@ -89,120 +268,6 @@ internal sealed class ConversionApplicationCreationServiceTests
 	//    // assert
 	//    Assert.DoesNotThrowAsync(() => recordModelService.UpdateDraftApplication(trustApplicationDto));
 	//}
-
-	/// <summary>
-	/// call add school endpoint and mock HttpStatusCode.Created
-	/// </summary>
-	//[Test]
-	public async Task AddSchoolToApplication___ApiReturns200___Ok()
-    {
-	    // arrange
-	    var expectedJson = @"{ ""foo"": ""bar"" }"; // TODO MR:- will be json from Academies API
-	    var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
-	    var mockLogger = new Mock<ILogger<ConversionApplicationCreationService>>();
-	    int applicationId = Fixture.Create<int>();
-        int urn = Fixture.Create<int>();
-        string schoolName = Fixture.Create<string>();
-
-        // act
-        var recordModelService = new ConversionApplicationCreationService(mockFactory.Object, mockLogger.Object);
-
-	    // assert
-	    Assert.DoesNotThrowAsync(() => recordModelService.AddSchoolToApplication(applicationId, urn, schoolName));
-    }
-
-    /// <summary>
-    /// call add school endpoint and mock HttpStatusCode.InternalServerError
-    /// </summary>
-    //[Test]
-    public async Task AddSchoolToApplication___ApiReturns500___InternalServerError()
-    {
-	    // arrange
-	    var expectedJson = @"{ ""foo"": ""bar"" }"; // TODO MR:- will be json from Academies API
-	    var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.InternalServerError, expectedJson);
-	    var mockLogger = new Mock<ILogger<ConversionApplicationCreationService>>();
-	    int applicationId = Fixture.Create<int>();
-	    int urn = Fixture.Create<int>();
-	    string schoolName = Fixture.Create<string>();
-
-	    // act
-	    var recordModelService = new ConversionApplicationCreationService(mockFactory.Object, mockLogger.Object);
-
-        // assert
-        var ex = Assert.ThrowsAsync<HttpRequestException>(() => recordModelService.AddSchoolToApplication(applicationId, urn, schoolName));
-
-        // now we could test the exception itself
-        //Assert.That(ex.Message == "Blah");
-    }
-
-    /// <summary>
-    /// call endpoint and mock HttpStatusCode.Created
-    /// </summary>
-    //[Test]
-    public async Task ApplicationAddJoinTrustReasons___ApiReturns200___Ok()
-    {
-        // arrange
-        var expectedJson = @"{ ""foo"": ""bar"" }"; // TODO MR:- will be json from Academies API
-        var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
-        var mockLogger = new Mock<ILogger<ConversionApplicationCreationService>>();
-        string ApplicationAddJoinTrustReason = Fixture.Create<string>();
-        int applicationId = Fixture.Create<int>();
-		int urn = Fixture.Create<int>();
-
-		// act
-		var recordModelService = new ConversionApplicationCreationService(mockFactory.Object, mockLogger.Object);
-
-        // assert
-        Assert.DoesNotThrowAsync(() => recordModelService.ApplicationAddJoinTrustReasons(applicationId, ApplicationAddJoinTrustReason, urn));
-    }
-
-    /// <summary>
-    /// call endpoint and mock HttpStatusCode.InternalServerError
-    /// </summary>
-    //[Test]
-    public async Task ApplicationAddJoinTrustReasons___ApiReturns500___InternalServerError()
-    {
-        // arrange
-        var expectedJson = @"{ ""foo"": ""bar"" }"; // TODO MR:- will be json from Academies API
-        var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.InternalServerError, expectedJson);
-        var mockLogger = new Mock<ILogger<ConversionApplicationCreationService>>();
-        int applicationId = Fixture.Create<int>();
-        int urn = Fixture.Create<int>();
-		string ApplicationAddJoinTrustReason = Fixture.Create<string>();
-
-        // act
-        var recordModelService = new ConversionApplicationCreationService(mockFactory.Object, mockLogger.Object);
-
-        // assert
-        var ex = Assert.ThrowsAsync<HttpRequestException>(() => recordModelService.ApplicationAddJoinTrustReasons(applicationId, ApplicationAddJoinTrustReason, urn));
-
-        // now we could test the exception itself
-        //Assert.That(ex.Message == "Blah");
-    }
-
-	// TODO MR:- ApplicationChangeSchoolNameAndReason - ApiReturns200___Ok()
-
-	// TODO MR:- ApplicationChangeSchoolNameAndReason - ApiReturns500___InternalServerError()
-
-	// TODO MR:- ApplicationSchoolTargetConversionDate - ApiReturns200___Ok()
-
-	// TODO MR:- ApplicationSchoolTargetConversionDate - ApiReturns500___InternalServerError()
-
-	// TODO MR:- ApplicationSchoolTargetConversionDate - ApiReturns200___Ok()
-
-	// TODO MR:- ApplicationSchoolTargetConversionDate - ApiReturns500___InternalServerError()
-
-	// TODO MR:- ApplicationSchoolFuturePupilNumbers - ApiReturns200___Ok()
-
-	// TODO MR:- ApplicationSchoolFuturePupilNumbers - ApiReturns500___InternalServerError()
-
-	// TODO MR:- ApplicationSchoolContacts - ApiReturns200___Ok()
-
-	// TODO MR:- ApplicationSchoolContacts - ApiReturns500___InternalServerError()
-
-	// TODO MR:- ApplicationSchoolLandAndBuildings - ApiReturns200___Ok()
-
-	// TODO MR:- ApplicationSchoolLandAndBuildings - ApiReturns500___InternalServerError()
 
 	private static Mock<IHttpClientFactory> SetupMockHttpClientFactory(HttpStatusCode expectedStatusCode, string expectedJson)
     {

--- a/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
+++ b/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
@@ -65,23 +65,6 @@ public abstract class BasePageEditModel : BasePageModel
 		};
 	}
 
-	protected void PopulateViewDataErrorsWithModelStateErrors()
-	{
-		ViewData["Errors"] = ConvertModelStateToDictionary();
-
-		if (!ModelState.IsValid)
-		{
-			foreach (var modelStateError in ConvertModelStateToDictionary())
-			{
-				// MR:- add friendly message for validation summary
-				if (!this.ValidationErrorMessagesViewModel.ValidationErrorMessages.ContainsKey(modelStateError.Key))
-				{
-					this.ValidationErrorMessagesViewModel.ValidationErrorMessages.Add(modelStateError.Key, modelStateError.Value);
-				}
-			}
-		}
-	}
-
 	private void CacheSelectedSchool(EstablishmentResponse? schoolDetails)
 	{
 		if (schoolDetails != null)

--- a/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
+++ b/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
@@ -9,7 +9,8 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
     private readonly HttpClient _httpClient;
     private readonly ResilientRequestProvider _resilientRequestProvider;
 
-	public ConversionApplicationCreationService(IHttpClientFactory httpClientFactory, ILogger<ConversionApplicationCreationService> logger) : base(httpClientFactory)
+	public ConversionApplicationCreationService(IHttpClientFactory httpClientFactory, 
+												ILogger<ConversionApplicationCreationService> logger) : base(httpClientFactory)
     {
 	    _httpClient = httpClientFactory.CreateClient(AcademisationAPIHttpClientName);
 		_logger = logger;
@@ -56,28 +57,7 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 		    throw;
 		}
     }
-
-	/////<inheritdoc/>
-	//public async Task UpdateDraftApplication(ConversionApplication application)
- //   {
-	//    try
-	//    {
-	//	    // MR:- may need to call GetApplication() first within ConversionApplicationRetrievalService()
-	//	    // to grab current application data
-	//	    // before then patching ConversionApplication returned with data from application object
-
-	//	    //https://academies-academisation-api-dev.azurewebsites.net/application/99
-	//	    string apiurl = $"{_httpClient.BaseAddress}application/{application.ApplicationId}?api-version=V1";
-
-	//	    // var result = await _resilientRequestProvider.PutAsync<ConversionApplicationApiPostResult, ConversionApplication>(apiurl, application);
-	//    }
-	//    catch (Exception ex)
-	//    {
-	//	    _logger.LogError("ConversionApplicationCreationService::AddSchoolToApplication::Exception - {Message}", ex.Message);
-	//	    throw;
-	//    }
-	//}
-
+	
 	///<inheritdoc/>
 	public async Task AddSchoolToApplication(int applicationId, int schoolUrn, string name)
     {
@@ -86,8 +66,10 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			// MR:- may need to call GetApplication() first within ConversionApplicationRetrievalService()
 			// to grab current application data
 			// before then patching ConversionApplication returned with data from application object
+			// var application = ;
 
-			//https://academies-academisation-api-dev.azurewebsites.net/application/99
+			//// baseaddress has a backslash at the end to be a valid URI !!!
+			//// https://academies-academisation-api-dev.azurewebsites.net/application/99
 			string apiurl = $"{_httpClient.BaseAddress}application/{applicationId}?api-version=V1";
 
 			SchoolApplyingToConvert school = new(name, schoolUrn, applicationId,null);
@@ -95,7 +77,8 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			//application.Schools.Add(school);
 
 			// TODO: wire up Academisation API / what object does a PUT return
-			// var result = await _resilientRequestProvider.PutAsync<ConversionApplicationApiPostResult, ConversionApplication>(apiurl, application);
+			//// structure of JSON in body is having a 'contributors' prop - same as ConversionApplication() obj
+			// var result = await _resilientRequestProvider.PutAsync<ConversionApplication, ConversionApplication>(apiurl, application);
 		}
 		catch (Exception ex)
 	    {
@@ -113,7 +96,8 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			// to grab current application data
 			// before then patching ConversionApplication returned with data from application object
 
-			//https://academies-academisation-api-dev.azurewebsites.net/application/99
+			//// baseaddress has a backslash at the end to be a valid URI !!!
+			//// https://academies-academisation-api-dev.azurewebsites.net/application/99
 			string apiurl = $"{_httpClient.BaseAddress}application/{applicationId}?api-version=V1";
 
 			// application can contain multiple schools so need to grab one being changed via linqage
@@ -139,7 +123,8 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			// to grab current application data
 			// before then patching ConversionApplication returned with data from application object
 
-			//https://academies-academisation-api-dev.azurewebsites.net/application/99
+			//// baseaddress has a backslash at the end to be a valid URI !!!
+			//// https://academies-academisation-api-dev.azurewebsites.net/application/99
 			string apiurl = $"{_httpClient.BaseAddress}application/{applicationId}?api-version=V1";
 
 			// TODO MR:- add to existing / form new route to think about here !
@@ -165,6 +150,10 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			// to grab current application data
 			// before then patching ConversionApplication returned with data from application object
 
+			//// baseaddress has a backslash at the end to be a valid URI !!!
+			//// https://academies-academisation-api-dev.azurewebsites.net/application/99
+			string apiurl = $"{_httpClient.BaseAddress}application/{application.ApplicationId}?api-version=V1";
+
 			// application can contain multiple schools so need to grab one being changed via linqage
 			var schoolUpdating = application.Schools.FirstOrDefault( s=> s.URN == schoolUrn);
 			//schoolUpdating.ProposedNewSchoolName
@@ -189,6 +178,10 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			// MR:- may need to call GetApplication() first within ConversionApplicationRetrievalService()
 			// to grab current application data
 			// before then patching ConversionApplication returned with data from application object
+
+			//// baseaddress has a backslash at the end to be a valid URI !!!
+			//// https://academies-academisation-api-dev.azurewebsites.net/application/99
+			string apiurl = $"{_httpClient.BaseAddress}application/{applicationId}?api-version=V1";
 
 			// application can contain multiple schools so need to grab one being changed via linqage
 			//var schoolUpdating = application.Schools.FirstOrDefault(s => s.URN == schoolUrn);
@@ -216,6 +209,10 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			// to grab current application data
 			// before then patching ConversionApplication returned with data from application object
 
+			//// baseaddress has a backslash at the end to be a valid URI !!!
+			//// https://academies-academisation-api-dev.azurewebsites.net/application/99
+			string apiurl = $"{_httpClient.BaseAddress}application/{applicationId}?api-version=V1";
+
 			// application can contain multiple schools so need to grab one being changed via linqage
 			//var schoolUpdating = application.Schools.FirstOrDefault(s => s.URN == schoolUrn);
 			//schoolUpdating.ProjectedPupilNumbersYear1 = projectedPupilNumbersYear1
@@ -242,6 +239,10 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			// MR:- may need to call GetApplication() first within ConversionApplicationRetrievalService()
 			// to grab current application data
 			// before then patching ConversionApplication returned with data from application object
+
+			//// baseaddress has a backslash at the end to be a valid URI !!!
+			//// https://academies-academisation-api-dev.azurewebsites.net/application/99
+			string apiurl = $"{_httpClient.BaseAddress}application/{schoolContacts.ApplicationId}?api-version=V1";
 
 			// application can contain multiple schools so need to grab one being changed via linqage
 			//var schoolUpdating = application.Schools.FirstOrDefault(s => s.URN == schoolContacts.Urn);
@@ -271,6 +272,10 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			// to grab current application data
 			// before then patching ConversionApplication returned with data from application object
 
+			//// baseaddress has a backslash at the end to be a valid URI !!!
+			//// https://academies-academisation-api-dev.azurewebsites.net/application/99
+			string apiurl = $"{_httpClient.BaseAddress}application/{schoolLandAndBuildings.ApplicationId}?api-version=V1";
+
 			// application can contain multiple schools so need to grab one being changed via linqage
 			//var schoolUpdating = application.Schools.FirstOrDefault(s => s.URN == schoolLandAndBuildings.Urn);
 			//schoolUpdating.SchoolBuildLandOwnerExplained = schoolLandAndBuildings.SchoolBuildLandOwnerExplained;
@@ -299,6 +304,10 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			// to grab current application data
 			// before then patching ConversionApplication returned with data from application object
 
+			//// baseaddress has a backslash at the end to be a valid URI !!!
+			//// https://academies-academisation-api-dev.azurewebsites.net/application/99
+			//string apiurl = $"{_httpClient.BaseAddress}application/{applicationId}?api-version=V1";
+
 			// application can contain multiple schools so need to grab one being changed via linqage
 			//var schoolUpdating = application.Schools.FirstOrDefault(s => s.URN == schoolLandAndBuildings.Urn);
 
@@ -320,4 +329,25 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			throw;
 		}
 	}
+
+	/////<inheritdoc/>
+	//public async Task UpdateDraftApplication(ConversionApplication application)
+	//   {
+	//    try
+	//    {
+	//	    // MR:- may need to call GetApplication() first within ConversionApplicationRetrievalService()
+	//	    // to grab current application data
+	//	    // before then patching ConversionApplication returned with data from application object
+
+	//	    //https://academies-academisation-api-dev.azurewebsites.net/application/99
+	//	    string apiurl = $"{_httpClient.BaseAddress}application/{application.ApplicationId}?api-version=V1";
+
+	//	    // var result = await _resilientRequestProvider.PutAsync<ConversionApplicationApiPostResult, ConversionApplication>(apiurl, application);
+	//    }
+	//    catch (Exception ex)
+	//    {
+	//	    _logger.LogError("ConversionApplicationCreationService::AddSchoolToApplication::Exception - {Message}", ex.Message);
+	//	    throw;
+	//    }
+	//}
 }

--- a/Dfe.Academies.External.Web/Services/ResilientRequestProvider.cs
+++ b/Dfe.Academies.External.Web/Services/ResilientRequestProvider.cs
@@ -87,7 +87,7 @@ namespace Dfe.Academies.External.Web.Services
             var response = await this._client.PutAsync(uri, content);
             response.EnsureSuccessStatusCode();
 
-            // using stream reader as below
+            // get PUT response JSON using stream reader as below
             result = await this.ConvertResponseContent<TResult>(response);
 
             return result;
@@ -123,7 +123,9 @@ namespace Dfe.Academies.External.Web.Services
         /// </returns>
         private async Task<TResult> ConvertResponseContent<TResult>(HttpResponseMessage response)
         {
-	        var options = new JsonSerializerOptions
+	        TResult result = default;
+
+			var options = new JsonSerializerOptions
 	        {
 		        AllowTrailingCommas = true,
 		        PropertyNameCaseInsensitive = true,
@@ -136,7 +138,12 @@ namespace Dfe.Academies.External.Web.Services
             await using var stream = await response.Content.ReadAsStreamAsync();
             using var reader = new StreamReader(stream);
             string text = reader.ReadToEnd();
-            TResult result = await Task.Run(() => JsonSerializer.Deserialize<TResult>(text, options));
+
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+	            result = await Task.Run(() => JsonSerializer.Deserialize<TResult>(text, options));
+			}
+
             return result;
         }
 


### PR DESCRIPTION
Plumbing in PUT API endpoint to add a school to an application after it's been created. As per ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/104118?McasTsid=26110

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
When a user selects a school through the application the selected school (urn & name) should be sent to the API

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. run Unit tests - as change made to resilient request provider - although CI / CD does this for you
2. Test application by:-
3.
4.

## Prerequisites
n/a