### PR TITLE
Bug routing fixes url params

### DIFF
--- a/Dfe.Academies.External.Web.UnitTest/Models/SchoolApplyingToConvertTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Models/SchoolApplyingToConvertTests.cs
@@ -13,11 +13,10 @@ internal sealed class SchoolApplyingToConvertTests
     public void Constructor___PropertiesSet()
     {
         // arrange
-        int applicationId = Fixture.Create<int>();
         int urn = Fixture.Create<int>();
         string schoolName = Fixture.Create<string>();
 
-        var conversionApplication = new SchoolApplyingToConvert(schoolName, urn, applicationId, null);
+        var conversionApplication = new SchoolApplyingToConvert(schoolName, urn, null);
 
         // act
         // nothing!

--- a/Dfe.Academies.External.Web/Models/SchoolApplyingToConvert.cs
+++ b/Dfe.Academies.External.Web/Models/SchoolApplyingToConvert.cs
@@ -2,15 +2,12 @@
 
 public class SchoolApplyingToConvert
 {
-	public SchoolApplyingToConvert(string schoolName, int urn, int applicationId, string? ukprn)
+	public SchoolApplyingToConvert(string schoolName, int urn, string? ukprn)
 	{
 		SchoolName = schoolName;
 		UKPRN = ukprn;
 		URN = urn;
-        ApplicationId = applicationId;
 	}
-
-	public int ApplicationId { get; set; }
 
     /// <summary>
     /// Unique school Id (6 digit number) e.g. 101934
@@ -41,7 +38,7 @@ public class SchoolApplyingToConvert
 	public string SchoolConversionApproverContactEmail { get; set; }
 
 	//// ApplicationConversionTargetDate
-	public DateTime SchoolConversionTargetDate { get; set; }
+	public DateTime? SchoolConversionTargetDate { get; set; }
 	public string SchoolConversionTargetDateExplained { get; set; }
 
 	//// ApplicationChangeSchoolName

--- a/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
+++ b/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
@@ -36,7 +36,7 @@ public abstract class BasePageEditModel : BasePageModel
 
 		CacheSelectedSchool(schoolDetails);
 
-		return ConvertApiResponseToModel(schoolDetails, applicationId);
+		return ConvertApiResponseToModel(schoolDetails);
 	}
 
 	public void LoadAndStoreCachedConversionApplication()
@@ -92,11 +92,11 @@ public abstract class BasePageEditModel : BasePageModel
 		}
 	}
 
-	private SchoolApplyingToConvert? ConvertApiResponseToModel(EstablishmentResponse? schoolDetails, int applicationId)
+	private SchoolApplyingToConvert? ConvertApiResponseToModel(EstablishmentResponse? schoolDetails)
 	{
 		if (schoolDetails != null)
 		{
-			return new SchoolApplyingToConvert(schoolDetails.EstablishmentName, Convert.ToInt32(schoolDetails.Urn), applicationId, schoolDetails.UPRN);
+			return new SchoolApplyingToConvert(schoolDetails.EstablishmentName, Convert.ToInt32(schoolDetails.Urn),schoolDetails.UPRN);
 		}
 		else
 		{

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationChangeSchoolName.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationChangeSchoolName.cshtml.cs
@@ -57,6 +57,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 				LoadAndStoreCachedConversionApplication();
 
 				var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
+				ApplicationId = appId;
+				Urn = urn;
 
 				// Grab other values from API
 				if (selectedSchool != null)
@@ -115,8 +117,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 		{
-			ApplicationId = selectedSchool.ApplicationId;
-			Urn = selectedSchool.URN;
+			// TODO MR:- populate other props from API - not implemented 18/08/2022
+			//ChangeSchoolName = ;
 		}
 	}
 }

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
@@ -99,6 +99,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 				LoadAndStoreCachedConversionApplication();
 
 				var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
+				ApplicationId = appId;
+				Urn = urn;
 
 				// Grab other values from API
 				if (selectedSchool != null)
@@ -168,8 +170,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 		{
-			ApplicationId = selectedSchool.ApplicationId;
-			Urn = selectedSchool.URN;
 			SchoolName = selectedSchool.SchoolName;
 			// TODO MR:- bind below from API data
 			//TargetDateDifferent = ;

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationJoinTrustReasons.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationJoinTrustReasons.cshtml.cs
@@ -41,9 +41,11 @@ namespace Dfe.Academies.External.Web.Pages.School
 			    LoadAndStoreCachedConversionApplication();
 
 				var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
+				ApplicationId = appId;
+				Urn = urn;
 
-			    // Grab other values from API
-			    if (selectedSchool != null)
+				// Grab other values from API
+				if (selectedSchool != null)
 			    {
 				    // TODO MR:- grab existing reasons for joining from API endpoint - applicationId && SchoolId combination !
 
@@ -92,8 +94,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 
         private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
         {
-            ApplicationId = selectedSchool.ApplicationId;
-            Urn = selectedSchool.URN;
-        }
-    }
+			// TODO MR:- populate other props from API - not implemented 18/08/2022
+			//ApplicationJoinTrustReason = ;
+		}
+	}
 }

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrant.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrant.cshtml.cs
@@ -71,6 +71,8 @@ public class ApplicationPreOpeningSupportGrantModel : BasePageEditModel
 			var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
 			var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
+			ApplicationId = appId;
+			Urn = urn;
 
 			// Grab other values from API
 			if (selectedSchool != null)
@@ -145,8 +147,6 @@ public class ApplicationPreOpeningSupportGrantModel : BasePageEditModel
 	private void PopulateUiModel(SchoolApplyingToConvert selectedSchool, ConversionApplication? conversionApplication)
 	{
 		ApplicationType = conversionApplication.ApplicationType;
-		ApplicationId = selectedSchool.ApplicationId;
-		Urn = selectedSchool.URN;
 		SchoolName = selectedSchool.SchoolName;
 		if (conversionApplication.ApplicationType != ApplicationTypes.JoinAMat)
 		{

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrantSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrantSummary.cshtml
@@ -8,7 +8,7 @@
 
 @section BeforeMain
 {
-    <a asp-page="../ApplicationOverview" class="govuk-back-link">Back to application overview</a>
+    <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back to application overview</a>
 }
 
 <div class="govuk-grid-column-two-thirds">
@@ -54,7 +54,7 @@
         <div class="govuk-!-margin-6"></div>
     }
 
-	<a asp-page="../ApplicationOverview" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
+    <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
 <input type="hidden" asp-for="Urn" />
 <partial name="_HiddenFields" />

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrantSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrantSummary.cshtml.cs
@@ -37,6 +37,8 @@ public class ApplicationPreOpeningSupportGrantSummaryModel : BasePageEditModel
 			LoadAndStoreCachedConversionApplication();
 
 			var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
+			ApplicationId = appId;
+			Urn = urn;
 
 			// Grab other values from API
 			if (selectedSchool != null)
@@ -60,8 +62,6 @@ public class ApplicationPreOpeningSupportGrantSummaryModel : BasePageEditModel
 
 	private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 	{
-		ApplicationId = selectedSchool.ApplicationId;
-		Urn = selectedSchool.URN;
 		SchoolName = selectedSchool.SchoolName;
 
 		ApplicationPreOpeningSupportGrantHeadingViewModel heading1 = new(ApplicationPreOpeningSupportGrantHeadingViewModel.Heading,

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
@@ -69,6 +69,8 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 			LoadAndStoreCachedConversionApplication();
 
 			var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
+			ApplicationId = appId;
+			Urn = urn;
 
 			// Grab other values from API
 			if (selectedSchool != null)
@@ -127,8 +129,6 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 
 	private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 	{
-		ApplicationId = selectedSchool.ApplicationId;
-		Urn = selectedSchool.URN;
 		SchoolName = selectedSchool.SchoolName;
 		// TODO MR:- populate other props from API - not implemented 22/08/2022
 		//SchoolConsultationStakeholders = selectedSchool.;

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml
@@ -8,7 +8,7 @@
 
 @section BeforeMain
 {
-	<a asp-page="../ApplicationOverview" class="govuk-back-link">Back to application overview</a>
+    <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back to application overview</a>
 }
 
 <div class="govuk-grid-column-two-thirds">
@@ -54,7 +54,7 @@
 		<div class="govuk-!-margin-6"></div>
 	}
 
-	<a asp-page="../ApplicationOverview" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
+    <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
 <input type="hidden" asp-for="Urn" />
 <partial name="_HiddenFields" />

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
@@ -37,6 +37,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 				LoadAndStoreCachedConversionApplication();
 
 				var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
+				ApplicationId = appId;
+				Urn = urn;
 
 				// Grab other values from API
 				if (selectedSchool != null)
@@ -60,8 +62,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 		{
-			ApplicationId = selectedSchool.ApplicationId;
-			Urn = selectedSchool.URN;
 			SchoolName = selectedSchool.SchoolName;
 
 			SchoolConsultationSummaryHeadingViewModel heading1 = new(SchoolPupilNumbersSummaryHeadingViewModel.Heading,

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSelectSchool.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSelectSchool.cshtml
@@ -6,7 +6,7 @@
 
 @section BeforeMain
 {
-	<a asp-page="SchoolOverview" class="govuk-back-link">Back to school overview</a>
+	<a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back to application overview</a>
 }
 
 <div class="ccms-loader govuk-!-display-none"></div>

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml.cs
@@ -1,4 +1,4 @@
-using Dfe.Academies.External.Web.Attributes;
+﻿using Dfe.Academies.External.Web.Attributes;
 using Dfe.Academies.External.Web.Enums;
 using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
@@ -172,6 +172,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 				LoadAndStoreCachedConversionApplication();
 
 				var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
+				ApplicationId = appId;
+				Urn = urn;
 
 				// Grab other values from API
 				if (selectedSchool != null)
@@ -260,8 +262,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 		{
-			ApplicationId = selectedSchool.ApplicationId;
-			Urn = selectedSchool.URN;
 			SchoolName = selectedSchool.SchoolName;
 			// TODO MR:- populate other props from API - not implemented 18/08/2022
 			//SchoolBuildLandOwnerExplained = ;

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml
@@ -8,7 +8,7 @@
 
 @section BeforeMain
 	{
-	<a asp-page="../ApplicationOverview" class="govuk-back-link">Back to application overview</a>
+    <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back to application overview</a>
 }
 
 <div class="govuk-grid-column-full">
@@ -54,7 +54,7 @@
 		<div class="govuk-!-margin-6"></div>
 	}
 
-	<a asp-page="../ApplicationOverview" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
+    <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
 <input type="hidden" asp-for="Urn" />
 <partial name="_HiddenFields" />

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
@@ -1,4 +1,4 @@
-using Dfe.Academies.External.Web.Models;
+﻿using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
 using Dfe.Academies.External.Web.ViewModels;
@@ -37,6 +37,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 				LoadAndStoreCachedConversionApplication();
 
 				var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
+				ApplicationId = appId;
+				Urn = urn;
 
 				// Grab other values from API
 				if (selectedSchool != null)
@@ -60,8 +62,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 		{
-			ApplicationId = selectedSchool.ApplicationId;
-			Urn = selectedSchool.URN;
 			SchoolName = selectedSchool.SchoolName;
 
 			SchoolLandAndBuildingsSummaryHeadingViewModel heading1 = new(SchoolLandAndBuildingsSummaryHeadingViewModel.Heading,

--- a/Dfe.Academies.External.Web/Pages/School/PupilNumbers.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/PupilNumbers.cshtml.cs
@@ -60,9 +60,11 @@ namespace Dfe.Academies.External.Web.Pages.School
 	            LoadAndStoreCachedConversionApplication();
 
                 var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
+                ApplicationId = appId;
+                Urn = urn;
 
-                // Grab other values from API
-                if (selectedSchool != null)
+				// Grab other values from API
+				if (selectedSchool != null)
                 {
 	                // TODO MR:- grab existing pupil numbers from API endpoint to populate VM - applicationId && SchoolId combination !
 
@@ -112,8 +114,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 
         private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
         {
-            ApplicationId = selectedSchool.ApplicationId;
-            Urn = selectedSchool.URN;
 	        SchoolName = selectedSchool.SchoolName;
 	        SchoolCapacityPublishedAdmissionsNumber = selectedSchool.SchoolCapacityPublishedAdmissionsNumber;
 	        ProjectedPupilNumbersYear1 = selectedSchool.ProjectedPupilNumbersYear1;

--- a/Dfe.Academies.External.Web/Pages/School/PupilNumbersSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/PupilNumbersSummary.cshtml
@@ -8,7 +8,7 @@
 
 @section BeforeMain
 {
-	<a asp-page="../ApplicationOverview" class="govuk-back-link">Back to application overview</a>
+    <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back to application overview</a>
 }
 
 <div class="govuk-grid-column-two-thirds">
@@ -54,7 +54,7 @@
 		<div class="govuk-!-margin-6"></div>
 	}
 
-	<a asp-page="../ApplicationOverview" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
+    <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
 <input type="hidden" asp-for="Urn" />
 <partial name="_HiddenFields" />

--- a/Dfe.Academies.External.Web/Pages/School/PupilNumbersSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/PupilNumbersSummary.cshtml.cs
@@ -37,9 +37,11 @@ namespace Dfe.Academies.External.Web.Pages.School
 			    LoadAndStoreCachedConversionApplication();
 
 			    var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
+			    ApplicationId = appId;
+			    Urn = urn;
 
-			    // Grab other values from API
-			    if (selectedSchool != null)
+				// Grab other values from API
+				if (selectedSchool != null)
 			    {
 				    // TODO MR:- grab data from API endpoint - applicationId && SchoolId combination !
 					// pupil numbers are stored against the school !
@@ -61,8 +63,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 		{
-			ApplicationId = selectedSchool.ApplicationId;
-			Urn = selectedSchool.URN;
 			SchoolName = selectedSchool.SchoolName;
 
 			SchoolPupilNumbersSummaryHeadingViewModel heading1 = new(SchoolPupilNumbersSummaryHeadingViewModel.Heading,

--- a/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml
@@ -8,7 +8,7 @@
 
 @section BeforeMain
 {
-	<a asp-page="../ApplicationOverview" class="govuk-back-link">Back to application overview</a>
+    <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back to application overview</a>
 }
 
 <div class="govuk-grid-column-two-thirds">

--- a/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml
@@ -58,7 +58,8 @@
 		<div class="govuk-!-margin-6"></div>
 	}
 
-	<a asp-page="SchoolOverview" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
+    <a asp-page="SchoolOverview" asp-route-appId="@Model.ApplicationId" asp-route-urn="@Model.Urn"
+	   class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
 <input type="hidden" asp-for="Urn"/>
 <partial name="_HiddenFields"/>

--- a/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml.cs
@@ -42,6 +42,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 				LoadAndStoreCachedConversionApplication();
 
 				var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
+				ApplicationId = appId;
+				Urn = urn;
 
 				// Grab other values from API
 				if (selectedSchool != null)
@@ -65,8 +67,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 		{
-			ApplicationId = selectedSchool.ApplicationId;
-			Urn = selectedSchool.URN;
 			SchoolName = selectedSchool.SchoolName;
 
 			SchoolConversionComponentHeadingViewModel heading1 = new(SchoolConversionComponentHeadingViewModel.HeadingApplicationSchool,

--- a/Dfe.Academies.External.Web/Pages/School/SchoolMainContacts.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolMainContacts.cshtml.cs
@@ -91,7 +91,9 @@ namespace Dfe.Academies.External.Web.Pages.School
 		    {
 			    LoadAndStoreCachedConversionApplication();
 
-			    var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
+			    ApplicationId = appId;
+			    Urn = urn;
+				var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
 
 			    // Grab other values from API
 			    if (selectedSchool != null)
@@ -170,11 +172,9 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 	    private void PopulateUiModel(SchoolApplyingToConvert selectedSchool, ApplicationTypes applicationType)
 	    {
-		    ApplicationId = selectedSchool.ApplicationId;
-		    Urn = selectedSchool.URN;
 		    SchoolName = selectedSchool.SchoolName;
 
-		    ViewModel = new ApplicationSchoolContactsViewModel(selectedSchool.ApplicationId, selectedSchool.URN)
+		    ViewModel = new ApplicationSchoolContactsViewModel(ApplicationId, selectedSchool.URN)
 			    {
 				    ContactHeadName = selectedSchool.SchoolConversionContactHeadName,
 					ContactHeadEmail = selectedSchool.SchoolConversionContactHeadEmail,

--- a/Dfe.Academies.External.Web/Pages/School/SchoolOverview.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolOverview.cshtml
@@ -8,7 +8,7 @@
 
 @section BeforeMain
 {
-	<a asp-page="../ApplicationOverview" class="govuk-back-link">Back to application overview</a>
+    <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back to application overview</a>
 }
 
 <div class="govuk-grid-column-two-thirds">
@@ -25,7 +25,7 @@
 
 	<partial name="_SchoolComponentsStatusPartial" model="Model.SchoolComponents"/>
 
-	<a asp-page="../ApplicationOverview" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
+        <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
-<input type="hidden" value="@Model.URN"/>
+<input type="hidden" value="@Model.Urn"/>
 <partial name="_HiddenFields"/>

--- a/Dfe.Academies.External.Web/Pages/School/SchoolOverview.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolOverview.cshtml.cs
@@ -1,8 +1,10 @@
-﻿using Dfe.Academies.External.Web.Enums;
+﻿using System;
+using Dfe.Academies.External.Web.Enums;
 using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
 using Dfe.Academies.External.Web.ViewModels;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Dfe.Academies.External.Web.Pages.School
 {
@@ -10,7 +12,10 @@ namespace Dfe.Academies.External.Web.Pages.School
     {
 	    private readonly ILogger<SchoolOverviewModel> _logger;
 
-	    public int URN { get; set; }
+	    [BindProperty]
+	    public int ApplicationId { get; set; }
+
+		public int Urn { get; set; }
 
         public string SchoolName { get; private set; } = string.Empty;
 
@@ -32,9 +37,11 @@ namespace Dfe.Academies.External.Web.Pages.School
 	        {
 				var conversionApplication = await LoadAndSetApplicationDetails(appId);
 				var selectedSchool = await LoadAndSetSchoolDetails(appId, urn);
+				ApplicationId = appId;
+				Urn = urn;
 
-                // Grab other values from API
-                if (selectedSchool != null)
+				// Grab other values from API
+				if (selectedSchool != null)
                 {
 	                selectedSchool.SchoolApplicationComponents = await ConversionApplicationRetrievalService
 		                .GetSchoolApplicationComponents(appId, urn);
@@ -50,7 +57,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 
         private void PopulateUiModel(SchoolApplyingToConvert selectedSchool, ConversionApplication? application)
         {
-	        URN = selectedSchool.URN;
             SchoolName = selectedSchool.SchoolName;
 
             ApplicationType = application.ApplicationType;

--- a/Dfe.Academies.External.Web/Pages/Trust/ApplicationSelectTrust.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/ApplicationSelectTrust.cshtml
@@ -6,7 +6,7 @@
 
 @section BeforeMain
 {
-	<a asp-page="YourApplications" class="govuk-back-link">Back</a>
+	<a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back to application overview</a>
 }
 
 <div class="ccms-loader govuk-!-display-none"></div>

--- a/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
+++ b/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
@@ -90,7 +90,7 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			//https://academies-academisation-api-dev.azurewebsites.net/application/99
 			string apiurl = $"{_httpClient.BaseAddress}application/{applicationId}?api-version=V1";
 
-			SchoolApplyingToConvert school = new(name, schoolUrn, applicationId,null);
+			SchoolApplyingToConvert school = new(name, schoolUrn, null);
 
 			//application.Schools.Add(school);
 


### PR DESCRIPTION
Some links to ApplicationOverview / SchoolOverview & SchoolConversionKeyDetails didn't work as not passing URL params

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Back link to ApplicationOverview / SchoolOverview & SchoolConversionKeyDetails now work

## Steps to reproduce issue (if relevant)
Some links to ApplicationOverview / SchoolOverview & SchoolConversionKeyDetails didn't work as not passing URL params
1.
2.
3.
4.

## Steps to test this PR
1. ApplicationPreOpeningSupportGrantSummary - back link
2. ApplicationSchoolConsultationSummary - back link
3. LandAndBuildingsSummary - back link
4. PupilNumbersSummary - back link
5. SchoolConversionKeyDetails - back link
6. SchoolOverview - back link
7. ApplicationSelectSchool - back link

## Prerequisites
n/a
