### PR TITLE
Bug conversion date binding

### DIFF
--- a/Dfe.Academies.External.Web.UnitTest/Pages/School/ApplicationConversionTargetDateModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Pages/School/ApplicationConversionTargetDateModelTests.cs
@@ -1,4 +1,5 @@
-﻿using Dfe.Academies.External.Web.Pages.School;
+﻿using System.Threading.Tasks;
+using Dfe.Academies.External.Web.Pages.School;
 using Dfe.Academies.External.Web.Services;
 using Dfe.Academies.External.Web.UnitTest.Factories;
 using Microsoft.AspNetCore.Mvc;
@@ -8,8 +9,6 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
-using System;
-using System.Threading.Tasks;
 
 namespace Dfe.Academies.External.Web.UnitTest.Pages.School
 {

--- a/Dfe.Academies.External.Web.UnitTest/Pages/School/ApplicationConversionTargetDateModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Pages/School/ApplicationConversionTargetDateModelTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
+using System;
 using System.Threading.Tasks;
 
 namespace Dfe.Academies.External.Web.UnitTest.Pages.School
@@ -117,6 +118,56 @@ namespace Dfe.Academies.External.Web.UnitTest.Pages.School
 
 		// TODO MR:- OnPostAsync___ModelIsValid___Valid
 		// when academisation API is implemented, will need to mock ResilientRequestProvider for http client API responses
+
+		[Test]
+		public void BuildDateTime__Valid()
+		{
+			// arrange
+			var mockConversionApplicationRetrievalService = new Mock<IConversionApplicationRetrievalService>();
+			var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
+			var mockConversionApplicationCreationService = new Mock<IConversionApplicationCreationService>();
+			var mockLogger = new Mock<ILogger<ApplicationConversionTargetDateModel>>();
+			string day = "21";
+			string month = "12";
+			string year = "2022";
+
+			// act
+			var pageModel = SetupApplicationConversionTargetDateModel(mockLogger.Object,
+				mockConversionApplicationCreationService.Object,
+				mockConversionApplicationRetrievalService.Object,
+				mockReferenceDataRetrievalService.Object);
+
+			// act
+			var dateTime = pageModel.BuildDateTime(day, month, year);
+
+			// assert
+			Assert.That(dateTime, Is.EqualTo(new DateTime(2022,12,21)));
+		}
+
+		[Test]
+		public void BuildDateTime__InValid()
+		{
+			// arrange
+			var mockConversionApplicationRetrievalService = new Mock<IConversionApplicationRetrievalService>();
+			var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
+			var mockConversionApplicationCreationService = new Mock<IConversionApplicationCreationService>();
+			var mockLogger = new Mock<ILogger<ApplicationConversionTargetDateModel>>();
+			string day = "30";
+			string month = "02";
+			string year = "2022";
+
+			// act
+			var pageModel = SetupApplicationConversionTargetDateModel(mockLogger.Object,
+				mockConversionApplicationCreationService.Object,
+				mockConversionApplicationRetrievalService.Object,
+				mockReferenceDataRetrievalService.Object);
+
+			// act
+			var dateTime = pageModel.BuildDateTime(day, month, year);
+
+			// assert
+			Assert.That(dateTime, Is.EqualTo(DateTime.MinValue));
+		}
 
 		private static ApplicationConversionTargetDateModel SetupApplicationConversionTargetDateModel(
 			ILogger<ApplicationConversionTargetDateModel> mockLogger,

--- a/Dfe.Academies.External.Web.UnitTest/Pages/School/ApplicationConversionTargetDateModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Pages/School/ApplicationConversionTargetDateModelTests.cs
@@ -118,57 +118,7 @@ namespace Dfe.Academies.External.Web.UnitTest.Pages.School
 
 		// TODO MR:- OnPostAsync___ModelIsValid___Valid
 		// when academisation API is implemented, will need to mock ResilientRequestProvider for http client API responses
-
-		[Test]
-		public void BuildDateTime__Valid()
-		{
-			// arrange
-			var mockConversionApplicationRetrievalService = new Mock<IConversionApplicationRetrievalService>();
-			var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
-			var mockConversionApplicationCreationService = new Mock<IConversionApplicationCreationService>();
-			var mockLogger = new Mock<ILogger<ApplicationConversionTargetDateModel>>();
-			string day = "21";
-			string month = "12";
-			string year = "2022";
-
-			// act
-			var pageModel = SetupApplicationConversionTargetDateModel(mockLogger.Object,
-				mockConversionApplicationCreationService.Object,
-				mockConversionApplicationRetrievalService.Object,
-				mockReferenceDataRetrievalService.Object);
-
-			// act
-			var dateTime = pageModel.BuildDateTime(day, month, year);
-
-			// assert
-			Assert.That(dateTime, Is.EqualTo(new DateTime(2022,12,21)));
-		}
-
-		[Test]
-		public void BuildDateTime__InValid()
-		{
-			// arrange
-			var mockConversionApplicationRetrievalService = new Mock<IConversionApplicationRetrievalService>();
-			var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
-			var mockConversionApplicationCreationService = new Mock<IConversionApplicationCreationService>();
-			var mockLogger = new Mock<ILogger<ApplicationConversionTargetDateModel>>();
-			string day = "30";
-			string month = "02";
-			string year = "2022";
-
-			// act
-			var pageModel = SetupApplicationConversionTargetDateModel(mockLogger.Object,
-				mockConversionApplicationCreationService.Object,
-				mockConversionApplicationRetrievalService.Object,
-				mockReferenceDataRetrievalService.Object);
-
-			// act
-			var dateTime = pageModel.BuildDateTime(day, month, year);
-
-			// assert
-			Assert.That(dateTime, Is.EqualTo(DateTime.MinValue));
-		}
-
+		
 		private static ApplicationConversionTargetDateModel SetupApplicationConversionTargetDateModel(
 			ILogger<ApplicationConversionTargetDateModel> mockLogger,
 			IConversionApplicationCreationService mockConversionApplicationCreationService,

--- a/Dfe.Academies.External.Web/Constants/FieldConstants.cs
+++ b/Dfe.Academies.External.Web/Constants/FieldConstants.cs
@@ -1,0 +1,279 @@
+﻿namespace Dfe.Academies.External.Web.Constants;
+
+internal static class FieldConstants
+{
+	public const string CurrentPage = "CurrentPage";
+	public const string NextPage = "NextPage";
+	public const string TrustName = "TrustName";
+	public const string SchoolName = "SchoolName";
+	public const string ViewProperties = "ViewProperties";
+	public const string ViewFileProperties = "ViewFileProperties";
+	public const string ApplicationTypeDescription = "ApplicationTypeDescription";
+	public const string ApplicationWordCountMax = "ApplicationWordCountMax";
+	public const string ApplicationFileSizeLimitMb = "ApplicationFileSizeLimitMb";
+	public const string ApplicationFileExtensionsAllowed = "ApplicationFileExtensionsAllowed";
+
+	public const string Name = "name";
+	public const string TrustSearchEstablishmentGroupIds = "TrustSearchEstablishmentGroupIds";
+	public const string SchoolSearchEstablishmentGroupIds = "SchoolSearchEstablishmentGroupIds";
+	public const string AreYouSure = "AreYouSure";
+
+	public const string SipEntity = "entity";
+	public const string SipApplication = "sip_applications";
+	public const string SipAccount = "accounts";
+	public const string SipAccountId = "accountid";
+	public const string SipApplyingSchool = "sip_applyingschoolses";
+	public const string SipApplyingSchoolLoan = "sip_schoolloans";
+	public const string SipApplyingSchoolLease = "sip_schoolleaseses";
+	public const string SipApplicationRecordStatus = "sip_externalapplicationrecordstatuses";
+	public const string SipEstablishmentGroupId = "_sip_establismenttypegroupid_value";
+	public const string SipKeyPerson = "sip_applicationkeypersons";
+	public const string SipContributor = "sip_contributors";
+
+	public const string SipName = "sip_name";
+	public const string SipCreatedOn = "createdon";
+	public const string SipApplicationType = "sip_a2capplicationtype";
+	public const string SipApplicationRole = "sip_a2capplicationrole";
+	public const string SipApplicationRoleOtherDescription = "sip_a2capplicationroleotherdescription";
+	public const string SipApplicationId = "sip_applicationid";
+	public const string SipApplicationTypeId = "sip_applicationtypeid";
+	public const string SipAddress1Composite = "address1_composite";
+	public const string SipApplicationLeadAuthorId = "sip_leadauthorid";
+	public const string SipApplicationLeadAuthorName = "sip_leadauthorname";
+	public const string SipApplicationLeadEmail = "sip_leadauthoremail";
+	public const string SipApplicationSubmitted = "sip_aplicationsubmitted";
+	public const string SipApplicationStatusId = "sip_applicationstatusid";
+	public const string SipApplicationSubmittedDate = "sip_submitteddate";
+	public const string SipApplicationUrl = "sip_applicationurl";
+
+	public const string SipApplicationRecordStatusId = "sip_externalapplicationrecordstatusid";
+	public const string SipApplicationRecordStatusKey = "sip_statuskey";
+	public const string SipApplicationRecordStatusValue = "sip_statusvalue";
+
+	public const string SipApplicationVersion = "sip_applicationtypeversion";
+
+	public const string SipContributorUserId = "sip_useridtext";
+	public const string SipContributorUserName = "sip_contributornametext";
+	public const string SipContributorAppIdText = "sip_applicationidtext";
+
+	#region Trust Constants
+
+	public const string SipTrustId = "sip_Trustid";
+	public const string SipTrustReferenceNumber = "sip_trustreferencenumber";
+	public const string SipTrustCompanyNumber = "sip_companieshousenumber";
+	public const string SipTrustApproverName = "sip_dfesigninapprover";
+	public const string SipTrustApproverEmail = "sip_dfesigninapproveremail";
+
+	#region JoinTrust
+	public const string SipChangesToTrust = "sip_changestothetrust";
+	public const string SipChangesToTrustExplained = "sip_changestotrustexplained";
+	public const string SipChangesToLAGovernance = "sip_changestolocalgovernancedueschooljoining";
+	public const string SipChangesToLAGovernanceExplained = "sip_changestolocalgovernanceexplained";
+	public const string SipChangesToTrustConsent = "sip_changestotrustconsent"; // File upload
+	#endregion JoinTrust
+
+	#region FormMat/SAT
+	// Name
+	public const string SipFormTrustProposedNameOfTrust = "sip_formtrustproposedname";
+
+	// Opening Date
+	public const string SipFormTrustOpeningDate = "sip_formtrustopeningdate";
+
+	// Reasons for forming trust
+	public const string SipFormTrustReasonForming = "sip_formtrustreasonforming";
+	public const string SipFormTrustReasonVision = "sip_formtrustreasonvision";
+	public const string SipFormTrustReasonGeoAreas = "sip_formtrustreasongeoareas";
+	public const string SipFormTrustReasonFreedom = "sip_formtrustreasonfreedom";
+	public const string SipFormTrustReasonImproveTeaching = "sip_formtrustreasonimproveteaching";
+	public const string SipFormTrustReasonApprovaltoConvertasSAT = "sip_rscofficeapprovaltoconvertassat";
+	public const string SipFormTrustReasonApprovedPerson = "sip_rscsatapprovedperson";
+
+
+	// Plans for growing
+	public const string SipFormTrustPlanForGrowth = "sip_formtrustplanforgrowth"; // File Upload
+	public const string SipFormTrustPlansForNoGrowth = "sip_whyareyounotplanningtogrow";
+	public const string SipFormTrustGrowthPlansYesNo = "sip_growthplanned";
+
+
+	// School improvement strategy
+	public const string SipFormTrustImprovementSupport = "sip_formtrustimprovementsupport";
+	public const string SipFormTrustImprovementStrategy = "sip_formtrustimprovementstrategy";
+	public const string SipFormTrustImprovementApprovedSponsor = "sip_formtrusiimprovementapprovedsponsor";
+
+	// Trust governance
+	public const string SipFormTrustGovernanceFile = "sip_formtrustgovernancefile";
+
+	// Key People
+	public const string SIPKeyPersonId = "sip_applicationkeypersonid";
+	public const string SIPKeyPersonBiography = "sip_biography";
+	public const string SIPKeyPersonCeoExecutive = "sip_ceoexecutive";
+	public const string SIPKeyPersonChairOfTrust = "sip_chairoftrust";
+	public const string SIPKeyPersonDateOfBirth = "sip_dateofbirth";
+	public const string SIPKeyPersonFinancialDirector = "sip_financialdirector";
+	public const string SIPKeyPersonFinancialDirectorTime = "sip_financialdirectortime";
+	public const string SIPKeyPersonMember = "sip_member";
+	public const string SIPKeyPersonName = "sip_name";
+	public const string SIPKeyPersonOther = "sip_other";
+	public const string SIPKeyPersonTrustee = "sip_trustee";
+
+
+	#endregion FormMat/SAT
+
+	#endregion Trust Constants
+
+	#region School Constants
+	public const string SipSchoolId = "sip_schoolid";
+	public const string SipApplyingSchoolsId = "sip_applyingschoolsid";
+	public const string SipApplyingSchoolId = "sip_applyingschoolid";
+	public const string SipUrn = "sip_urn";
+	public const string SipUpdatedTrustFields = "sip_updatedtrustfields";
+	public const string SipUpdatedSchoolFields = "sip_updatedschoolfields";
+
+	// Main Contact
+	public const string SipSchoolConversionContactHeadName = "sip_nameofheadteacher";
+	public const string SipSchoolConversionContactHeadEmail = "sip_headteacheremailaddress";
+	public const string SipSchoolConversionContactHeadTel = "sip_headteachertelephonenumber";
+	public const string SipSchoolConversionContactChairName = "sip_nameofthechairofthegoverningbody";
+	public const string SipSchoolConversionContactChairEmail = "sip_chairsemailaddress";
+	public const string SipSchoolConversionContactChairTel = "sip_chairstelephonenumber";
+	public const string SipSchoolConversionContactOther = "sip_maincontactfortheconversionprocess";
+	public const string SipSchoolConversionApproverContactName = "sip_newacademycontact";
+	public const string SipSchoolConversionApproverContactEmail = "sip_newacademycontactemail";
+	public const string SipSchoolConversionMainContact = "sip_schoolconversionmaincontact";
+	public const string SipSchoolConversionMainContactOtherName = "sip_schoolconversionmaincontactothername";
+	public const string SipSchoolConversionMainContactOtherEmail = "sip_schoolconversionmaincontactotheremail";
+	public const string SipSchoolConversionMainContactOtherTelephone = "sip_schoolconversionmaincontactothertelephone";
+	public const string SipSchoolConversionMainContactOtherRole = "sip_schoolconversionmaincontactotherrole";
+
+	// Conversion Target Date
+	public const string SipSchoolConversionTargetDateDifferent = "sip_ctddiferentdate";
+	public const string SipSchoolConversionTargetDateDate = "sip_ctddiferentdatevalue";
+	public const string SipSchoolConversionTargetDateExplained = "sip_ctddiferentdatevalueexplained";
+	public const string SipSchoolConversionChangeName = "sip_ctdchangename";
+	public const string SipSchoolConversionChangeNameValue = "sip_ctdchangenamevalue";
+
+	// Conversion Rationale
+	public const string SipSchoolConversionReasonsForJoining = "sip_ckdreasonsforjoining";
+
+	// Further Info
+	public const string SIPSchoolAdSchoolContributionToTrust = "sip_adschoolcontributiontotrust";
+	public const string SIPSchoolAdInspectedButReportNotPublished = "sip_adinspectedbutreportnotpublishedyet";
+	public const string SIPSchoolAdInspectedReportNotPublishedExplain = "sip_adinspectedbutreportnotpublishedyetexplai";
+	public const string SIPSchoolLaReorganization = "sip_adschoolpartoflareorganization";
+	public const string SIPSchoolLaReorganizationExplain = "sip_adschoolpartoflareorganizationexplained";
+	public const string SIPSchoolLaClosurePlans = "sip_adschoolpartoflaclosureplans";
+	public const string SIPSchoolLaClosurePlansExplain = "sip_adschoolpartoflaclosureplansexplained";
+	public const string SIPSchoolPartOfFederation = "sip_adschoolpartoffederation";
+	public const string SIPSchoolPartOfFederationExplained = "sip_adschoolpartoffederationplansexplained";
+	public const string SIPSchoolFurtherInformation = "sip_adschoolfurtherinformation";
+	public const string SIPSchoolAdSafeguarding = "sip_adschoolsafeguarding";
+	public const string SIPSchoolAdSafeguardingExplained = "sip_adschoolsafeguardingexplained";
+	public const string SIPSchoolSACREExemption = "sip_adschoolsacreexemption";
+	public const string SIPSchoolSACREExemptionEndDate = "sip_adschoolsacreexemptionenddate";
+	public const string SIPSchoolFaithSchool = "sip_adschoolfaithschool";
+	public const string SIPSchoolFaithSchoolDioceseName = "sip_adschoolfaithschooldiocesename";
+	public const string SIPSchoolFaithSchoolFile = "sip_adschoolfaithschoolfile";// File upload  
+	public const string SIPSchoolSupportedFoundation = "sip_adschoolsupportedfoundation";
+	public const string SIPSchoolSupportedFoundationBodyName = "sip_adschoolsupportedfoundationbodyname";
+	public const string SIPSchoolSupportedFoundationFile = "sip_adschoolsupportedfoundationfile";// File upload
+	public const string SIPSchoolAddFurtherInformation = "sip_adschooladdfurtherinformation";
+	public const string SIPSchoolGoverningBodyConsent = "sip_adschoolgoverningbodyconsent"; // File upload
+	public const string SIPSchoolAdFeederSchools = "sip_adschoolfeederschools";
+	public const string SIPSchoolAdEqualitiesImpactAssessment = "sip_adschoolequalityimpactassessment";
+
+	// Previous Financial Year
+	public const string SIPSchoolPFYEndDate = "sip_pfyenddate";
+	public const string SIPSchoolPFYRevenue = "sip_pfyrevenuepreviousfinancialyear";
+	public const string SIPSchoolPFYRevenueStatus = "sip_pfyrevenuepreviousfinancialstatus";
+	public const string SIPSchoolPFYRevenueStatusExplained = "sip_pfyrevenuepreviousfinancialstatusexplain";
+	public const string SIPSchoolPFYRevenueStatusFile = "sip_pfyrevenuepreviousfinancialstatusfile";// File Upload
+	public const string SIPSchoolPFYCapitalForward = "sip_pfyrevenuecapitalcarriedforward";
+	public const string SIPSchoolPFYCapitalForwardStatus = "sip_pfyrevenuecapitalcarriedforwardstatus";
+	public const string SIPSchoolPFYCapitalForwardStatusExplained = "sip_pfyrevenuecapitalcarriedforwardstatusexpl";
+	public const string SIPSchoolPFYCapitalForwardStatusFile = "sip_pfyrevenuecapitalcarriedforwardfile";// File Upload
+
+	// Current Financial Year
+	public const string SIPSchoolCFYEndDate = "sip_cfyenddate";
+	public const string SIPSchoolCFYRevenue = "sip_cfyrevenuecurrentfinancialyear";
+	public const string SIPSchoolCFYRevenueStatus = "sip_cfyrevenuecurrentfinancialstatus";
+	public const string SIPSchoolCFYRevenueStatusExplained = "sip_cfyrevenuecurrentfinancialstatusexplained";
+	public const string SIPSchoolCFYRevenueStatusFile = "sip_cfyrevenuecurrentfinancialstatusfile";// File Upload
+	public const string SIPSchoolCFYCapitalForward = "sip_cfyforecastcapitalcarriedforward";
+	public const string SIPSchoolCFYCapitalForwardStatus = "sip_cfyforecastcapitalcarriedforwardstatus";
+	public const string SIPSchoolCFYCapitalForwardStatusExplained = "sip_cfyforecastcapitalcarriedforwardstatusexp";
+	public const string SIPSchoolCFYCapitalForwardFile = "sip_cfyforecastcapitalcarriedforwardfile";// File Upload
+
+	// Next Financial Year
+	public const string SIPSchoolNFYEndDate = "sip_nfyenddate";
+	public const string SIPSchoolNFYRevenue = "sip_nfynextcurrentfinancialyear";
+	public const string SIPSchoolNFYRevenueStatus = "sip_nfynextcurrentfinancialstatus";
+	public const string SIPSchoolNFYRevenueStatusExplained = "sip_nfynextcurrentfinancialstatusexplained";
+	public const string SIPSchoolNFYRevenueStatusFile = "sip_nfynextcurrentfinancialfile"; // File Upload
+	public const string SIPSchoolNFYCapitalForward = "sip_nfyforecastcapitalcarriedforward";
+	public const string SIPSchoolNFYCapitalForwardStatus = "sip_nfyforecastcapitalcarriedforwardstatus";
+	public const string SIPSchoolNFYCapitalForwardStatusExplained = "sip_nfyforecastcapitalcarriedforwardstatusexp";
+	public const string SIPSchoolNFYCapitalForwardFile = "sip_nfyforecastcapitalcarriedforwardfile"; // File Upload
+
+	// Financial Investigations
+	public const string SIPSchoolFinancialInvestigations = "sip_financialinvestigations";
+	public const string SIPSchoolFinancialInvestigationsExplain = "sip_financialinvestigationsexplain";
+	public const string SIPSchoolFinancialInvestigationsTrustAware = "sip_financialinvestigationstrustaware";
+
+	// Loans
+	public const string SIPSchoolLoanId = "sip_schoolloanid";
+	public const string SIPSchoolLoanExists = "sip_loansexisting";
+	public const string SIPSchoolLoanAmount = "sip_ldtotalamount";
+	public const string SIPSchoolLoanPurpose = "sip_ldpurposeloan";
+	public const string SIPSchoolLoanProvider = "sip_ldprovider";
+	public const string SIPSchoolLoanInterestRate = "sip_ldinterestrate";
+	public const string SIPSchoolLoanSchedule = "sip_ldscheduleofpaymentexplain";
+
+	// Leases
+	public const string SIPSchoolLeaseExists = "sip_financiallease";
+	public const string SIPSchoolLeaseId = "sip_schoolleasesid";
+	public const string SIPSchoolLeaseTerm = "sip_financialdetails";
+	public const string SIPSchoolLeaseRepaymentValue = "sip_financialtotalamount";
+	public const string SIPSchoolLeaseInterestRate = "sip_interestrate";
+	public const string SIPSchoolLeasePaymentToDate = "sip_paymentsmadetodate";
+	public const string SIPSchoolLeasePurpose = "sip_financialpurpose";
+	public const string SIPSchoolLeaseValueOfAssets = "sip_valueofassets";
+	public const string SIPSchoolLeaseResponsibleForAssets = "sip_responsibilityforinsurancerepair";
+
+	// School capacity and pupil numbers on roll
+	public const string SIPSchoolCapacityYear1 = "sip_scpnprojectedpupilonrollyear1";
+	public const string SIPSchoolCapacityYear2 = "sip_scpnprojectedpupilonrollyear2";
+	public const string SIPSchoolCapacityYear3 = "sip_scpnprojectedpupilonrollyear3";
+	public const string SIPSchoolCapacityAssumptions = "sip_scpnassumptions";
+	public const string SIPSchoolCapacityPublishedAdmissionsNumber = "sip_scppublishedadmissionnumber";
+
+	// Land and buildings
+	public const string SIPSchoolBuildLandOwnerExplained = "sip_lbbuildlandownerexplained";
+	public const string SIPSchoolBuildLandSharedFacilities = "sip_lbfacilitiesshared";
+	public const string SIPSchoolBuildLandSharedFacilitiesExplained = "sip_lbfacililtiessharedexplained";
+	public const string SIPSchoolBuildLandWorksPlanned = "sip_lbworksplanned";
+	public const string SIPSchoolBuildLandWorksPlannedExplained = "sip_lbworksplannedexplained";
+	public const string SIPSchoolBuildLandWorksPlannedDate = "sip_lbworksplanneddate";
+	public const string SIPSchoolBuildLandGrants = "sip_lbgrants";
+	public const string SIPSchoolBuildLandGrantsExplained = "sip_lbgrantsexplained";
+	public const string SIPSchoolBuildLandGrantsBody = "sip_whichbodyawardedgrants";
+	public const string SIPSchoolBuildLandPFIScheme = "sip_partofpfischeme";
+	public const string SIPSchoolBuildLandPFISchemeType = "sip_partofpfischemetype";
+	public const string SIPSchoolBuildLandPriorityBuildingProgramme = "sip_partofpriorityschoolsbuildingprogramme";
+	public const string SIPSchoolBuildLandFutureProgramme = "sip_partofbuildingschoolsforfutureprogramne";
+
+	// Consultation  
+	public const string SIPSchoolConsultationStakeholders = "sip_stuatoryconsultationstakeholders";
+	public const string SIPSchoolConsultationStakeholdersConsult = "sip_statutoryconsultationplan";
+
+	// Support grant
+	public const string SIPSchoolSupportGrantFundsPaidTo = "sip_acsfundspaidto";
+
+	// Declaration
+	public const string SIPSchoolDeclarationBodyAgree = "sip_declargovernbodyagree";
+	public const string SIPSchoolDeclarationTeacherChair = "sip_declarheadteacherchair";
+	public const string SIPSchoolDeclarationSignedById = "sip_declarsignedbyid";
+	public const string SIPSchoolDeclarationSignedByName = "sip_declarsignedbyname";
+	public const string SIPSchoolDeclarationSignedByEmail = "sip_declarsignedbyemail";
+
+	#endregion School Constants
+}

--- a/Dfe.Academies.External.Web/Dfe.Academies.External.Web.csproj
+++ b/Dfe.Academies.External.Web/Dfe.Academies.External.Web.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Constants\FieldConstants.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="wwwroot\assets\application-39beab6507cd50944edb58ab76ca9a393e09d467cba25003fbd3104c8a02514b.js" />
   </ItemGroup>
 
@@ -22,6 +26,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Constants\" />
   </ItemGroup>
 
 </Project>

--- a/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
+++ b/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
@@ -1,9 +1,9 @@
-﻿using Dfe.Academies.External.Web.Models;
+﻿using System.Globalization;
+using Dfe.Academies.External.Web.AcademiesAPIResponseModels.Schools;
+using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Services;
 using Dfe.Academies.External.Web.ViewModels;
-using Dfe.Academies.External.Web.AcademiesAPIResponseModels.Schools;
 using Microsoft.Extensions.Primitives;
-using System.Globalization;
 
 namespace Dfe.Academies.External.Web.Pages.Base;
 

--- a/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
+++ b/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
@@ -2,6 +2,8 @@
 using Dfe.Academies.External.Web.Services;
 using Dfe.Academies.External.Web.ViewModels;
 using Dfe.Academies.External.Web.AcademiesAPIResponseModels.Schools;
+using Microsoft.Extensions.Primitives;
+using System.Globalization;
 
 namespace Dfe.Academies.External.Web.Pages.Base;
 
@@ -48,6 +50,22 @@ public abstract class BasePageEditModel : BasePageModel
 		TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
 	}
 
+	public Dictionary<string,string> RetrieveDateTimeComponentsFromDatePicker(IFormCollection form, string formControlName)
+	{
+		form.TryGetValue($"{formControlName}-day", out StringValues day);
+		form.TryGetValue($"{formControlName}-month", out StringValues month);
+		form.TryGetValue($"{formControlName}-year", out StringValues year);
+
+		Dictionary<string, string> dateComponents = new()
+			{
+				{ "day", day },
+				{ "month", month },
+				{ "year", year }
+			};
+
+		return dateComponents;
+	}
+
 	protected string SetSchoolApplicationComponentUriFromName(string componentName)
 	{
 		return componentName.ToLower().Trim() switch
@@ -85,5 +103,16 @@ public abstract class BasePageEditModel : BasePageModel
 		{
 			return null;
 		}
+	}
+
+	protected DateTime BuildDateTime(string day, string month, string year)
+	{
+		string dateString = $"{day}/{month}/{year}";
+		string format = "dd/MM/yyyy";
+
+		DateTime.TryParseExact(dateString, format, CultureInfo.InvariantCulture,
+			DateTimeStyles.None, out DateTime newDate);
+
+		return newDate;
 	}
 }

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml
@@ -67,19 +67,19 @@
 									<a href="#SchoolConversionTargetDateNotEntered" class="@(Model.SchoolConversionTargetDateError ? "govuk-error-message" : "govuk-visually-hidden")">
 										You must select a conversion date
 									</a>
-                                    <govuk-date field-name="@FieldConstants.SipSchoolConversionTargetDateDate"
+@*                                    <govuk-date field-name="@FieldConstants.SipSchoolConversionTargetDateDate"
 								              field-data="@ViewData[FieldConstants.SipSchoolConversionTargetDateDate]"
 								              field-day="@ViewData[FieldConstants.SipSchoolConversionTargetDateDate + "-day"]"
 								              field-month="@ViewData[FieldConstants.SipSchoolConversionTargetDateDate + "-month"]"
 								              field-year="@ViewData[FieldConstants.SipSchoolConversionTargetDateDate + "-year"]">
-								    </govuk-date>
+								    </govuk-date>*@
 
-@*									<govuk-date field-name="SchoolConversionTargetDate"
+									<govuk-date field-name="@FieldConstants.SipSchoolConversionTargetDateDate"
 									            field-data="@Model.TargetDate"
 									            field-day="@Model.TargetDateDay"
 									            field-month="@Model.TargetDateMonth"
 									            field-year="@Model.TargetDateYear">
-									</govuk-date>*@
+									</govuk-date>
 								</fieldset>
 
 								<div class="govuk-!-margin-6"></div>

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml
@@ -1,5 +1,4 @@
 ﻿@page
-@using Dfe.Academies.External.Web.Constants
 @using Dfe.Academies.External.Web.Enums
 @using Dfe.Academies.External.Web.Extensions
 @using Dfe.Academies.External.Web.TagHelpers
@@ -67,14 +66,7 @@
 									<a href="#SchoolConversionTargetDateNotEntered" class="@(Model.SchoolConversionTargetDateError ? "govuk-error-message" : "govuk-visually-hidden")">
 										You must select a conversion date
 									</a>
-@*                                    <govuk-date field-name="@FieldConstants.SipSchoolConversionTargetDateDate"
-								              field-data="@ViewData[FieldConstants.SipSchoolConversionTargetDateDate]"
-								              field-day="@ViewData[FieldConstants.SipSchoolConversionTargetDateDate + "-day"]"
-								              field-month="@ViewData[FieldConstants.SipSchoolConversionTargetDateDate + "-month"]"
-								              field-year="@ViewData[FieldConstants.SipSchoolConversionTargetDateDate + "-year"]">
-								    </govuk-date>*@
-
-									<govuk-date field-name="@FieldConstants.SipSchoolConversionTargetDateDate"
+                                    <govuk-date field-name="@Model.SchoolConversionTargetDateDate"
 									            field-data="@Model.TargetDate"
 									            field-day="@Model.TargetDateDay"
 									            field-month="@Model.TargetDateMonth"

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml
@@ -1,4 +1,5 @@
 ﻿@page
+@using Dfe.Academies.External.Web.Constants
 @using Dfe.Academies.External.Web.Enums
 @using Dfe.Academies.External.Web.Extensions
 @using Dfe.Academies.External.Web.TagHelpers
@@ -66,12 +67,19 @@
 									<a href="#SchoolConversionTargetDateNotEntered" class="@(Model.SchoolConversionTargetDateError ? "govuk-error-message" : "govuk-visually-hidden")">
 										You must select a conversion date
 									</a>
-									<govuk-date field-name="SchoolConversionTargetDate"
+                                    <govuk-date field-name="@FieldConstants.SipSchoolConversionTargetDateDate"
+								              field-data="@ViewData[FieldConstants.SipSchoolConversionTargetDateDate]"
+								              field-day="@ViewData[FieldConstants.SipSchoolConversionTargetDateDate + "-day"]"
+								              field-month="@ViewData[FieldConstants.SipSchoolConversionTargetDateDate + "-month"]"
+								              field-year="@ViewData[FieldConstants.SipSchoolConversionTargetDateDate + "-year"]">
+								    </govuk-date>
+
+@*									<govuk-date field-name="SchoolConversionTargetDate"
 									            field-data="@Model.TargetDate"
 									            field-day="@Model.TargetDateDay"
 									            field-month="@Model.TargetDateMonth"
 									            field-year="@Model.TargetDateYear">
-									</govuk-date>
+									</govuk-date>*@
 								</fieldset>
 
 								<div class="govuk-!-margin-6"></div>

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
@@ -1,11 +1,12 @@
-﻿using Dfe.Academies.External.Web.Constants;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using Dfe.Academies.External.Web.Constants;
 using Dfe.Academies.External.Web.Enums;
 using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
 using Microsoft.AspNetCore.Mvc;
-using System.ComponentModel.DataAnnotations;
-using System.Globalization;
+using Microsoft.Extensions.Primitives;
 
 namespace Dfe.Academies.External.Web.Pages.School
 {
@@ -35,7 +36,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 		/// i.e. day + month + year entered !
 		/// </summary>
 		[BindProperty]
-		public DateTime? TargetDate { get; set; }
+		public string? TargetDate { get; set; }
 
 		[BindProperty] // MR:- don't know whether I need this
 		public string? TargetDateDay { get; set; }
@@ -113,8 +114,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 				}
 
 				// MR:- code from a2c-sip for date picker - set up ViewData[] dictionary with object values in it
-				string newView = "ConversionTargetDate";
-				SetSchoolViewData(appId, selectedSchool, newView);
+				// string newView = "ConversionTargetDate";
+				// SetSchoolViewData(appId, selectedSchool, newView);
 			}
 			catch (Exception ex)
 			{
@@ -122,15 +123,24 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
-		public async Task<IActionResult> OnPostAsync()
+		public async Task<IActionResult> OnPostAsync(IFormCollection form)
 		{
+			//var id = Convert.ToInt32(form["ApplicationId"]);
+			form.TryGetValue($"{FieldConstants.SipSchoolConversionTargetDateDate}-day", out StringValues day);
+			form.TryGetValue($"{FieldConstants.SipSchoolConversionTargetDateDate}-month", out StringValues month);
+			form.TryGetValue($"{FieldConstants.SipSchoolConversionTargetDateDate}-year", out StringValues year);
+
+			// MR:- try and build a date from component parts !!!
+			var targetDate = BuildDateTime(day,month,year);
+
 			if (!ModelState.IsValid)
 			{
 				PopulateValidationMessages();
 				return Page();
 			}
 
-			if (TargetDateDifferent == SelectOption.Yes && !TargetDate.HasValue)
+			if ((TargetDateDifferent == SelectOption.Yes && !targetDate.HasValue) 
+			    || (TargetDateDifferent == SelectOption.Yes && targetDate.HasValue && targetDate.Value != DateTime.MinValue))
 			{
 				ModelState.AddModelError("SchoolConversionTargetDateNotEntered", "You must select a conversion date");
 				PopulateValidationMessages();
@@ -177,113 +187,123 @@ namespace Dfe.Academies.External.Web.Pages.School
 		{
 			SchoolName = selectedSchool.SchoolName;
 			// TODO MR:- bind below from API data
-			//TargetDateDifferent = ;
-			//TargetDate = ;
-			//TargetDateExplained = ;
+			// TargetDateDifferent = selectedSchool.;
+			// TargetDate = selectedSchool.;
+			// TargetDateExplained = selectedSchool.;
 		}
 
-		private void SetSchoolViewData(int appId, SchoolApplyingToConvert? school, string viewName)
+		//private void SetSchoolViewData(int appId, SchoolApplyingToConvert? school, string viewName)
+		//{
+		//	SetViewDataProperties(appId, viewName, school);
+
+		//	// MR:- not sure I need this??
+		//	ViewData[FieldConstants.SipApplyingSchoolsId] = school.URN;
+		//}
+
+		//private void SetViewDataProperties(int appId, string nextPage, object? entity)
+		//{
+		//	// MR:- not sure I need this??
+		//	SetCommonViewDataProperties(nextPage, appId);
+
+		//	if (appId != 0)
+		//	{
+		//		// create ViewData[] pointers for each property within 'object entity'
+		//		SetDataProperties(entity);
+		//	}
+		//}
+
+		///// <summary>
+		///// MR:- not sure I need this??
+		///// </summary>
+		///// <param name="nextPage"></param>
+		///// <param name="appId"></param>
+		//private void SetCommonViewDataProperties(string nextPage, int appId)
+		//{
+		//	ViewData[FieldConstants.CurrentPage] = nextPage;
+		//	ViewData[FieldConstants.SipApplicationId] = appId;
+		//}
+
+		///// <summary>
+		///// Sets the ViewData[] with the returned view properties
+		///// </summary>
+		///// <param name="entity">e.g. school object</param>
+		//private void SetDataProperties(object? entity)
+		//{
+		//	// MR:- get a dictionary / array / list of view property keys
+		//	var viewProperties = GetViewFieldProperties();
+		//	if (!viewProperties.Any())
+		//	{
+		//		return;
+		//	}
+
+		//	var data = entity.GetType()
+		//		.GetProperties()
+		//		.ToDictionary(property => property.Name, property => property.GetValue(entity));
+
+		//	// populate the ViewData[] value from the entity object
+		//	foreach (KeyValuePair<string, string> field in viewProperties)
+		//	{
+		//		var fieldName = field.Value; // property name
+
+		//		if (data.ContainsKey(fieldName))
+		//		{
+		//			ViewData[field.Key] = data[fieldName] switch
+		//			{
+		//				DateTime dateTime => dateTime.ToString(CultureInfo.CurrentCulture),
+		//				object obj => obj.ToString(),
+		//				_ => string.Empty
+		//			};
+		//		}
+		//		else
+		//		{
+		//			ViewData[field.Key] = string.Empty;
+		//		}
+		//	}
+		//}
+
+		///// <summary>
+		///// Get a list / dictionary / array of view / field names. 
+		///// This MUST match the property names of the object you're searching / matching
+		///// within SetDataProperties()
+		///// </summary>
+		///// <returns></returns>
+		//private Dictionary<string, string> GetViewFieldProperties()
+		//{
+		//	// add keys into dictionary representing conversion date properties / data
+		//	// what are consumed by govuk-date tag helper
+		//	Dictionary<string, string> viewFields = new()
+		//	{
+		//		{ FieldConstants.SipSchoolConversionTargetDateExplained, "SchoolConversionTargetDateExplained" },
+
+		//		{ FieldConstants.SipSchoolConversionTargetDateDate, "SchoolConversionTargetDate" },
+
+		//		// FieldConstants.SipSchoolConversionTargetDateDifferent - NOT in SchoolApplyingToConvert
+		//		// as NOT in API
+		//		{ FieldConstants.SipSchoolConversionTargetDateDifferent, "" },
+
+		//		// MR:- setting up 3 below as consumed by govuk-date tag helper
+		//		// value for below will be 'dd' component of "SchoolConversionTargetDate"
+		//		{ $"{FieldConstants.SipSchoolConversionTargetDateDate}-day", "" },
+
+		//		// value for below will be 'MM' component of "SchoolConversionTargetDate"
+		//		{ $"{FieldConstants.SipSchoolConversionTargetDateDate}-month", "" },
+
+		//		// value for below will be 'yyyy' component of "SchoolConversionTargetDate"
+		//		{ $"{FieldConstants.SipSchoolConversionTargetDateDate}-year", "" }
+		//	};
+
+		//	return viewFields;
+		//}
+
+		public DateTime? BuildDateTime(string day, string month, string year)
 		{
-			SetViewDataProperties(appId, viewName, school);
+			string dateString = $"{day}/{month}/{year}"; 
+			string format = "dd/MM/yyyy";
+			
+			DateTime.TryParseExact(dateString, format, CultureInfo.InvariantCulture,
+				DateTimeStyles.None, out DateTime newDate);
 
-			// MR:- not sure I need this??
-			ViewData[FieldConstants.SipApplyingSchoolsId] = school.URN;
+			return newDate;
 		}
-
-		private void SetViewDataProperties(int appId, string nextPage, object? entity)
-		{
-			// MR:- not sure I need this??
-			SetCommonViewDataProperties(nextPage, appId);
-
-			if (appId == 0)
-			{
-				// create ViewData[] pointers for each property within 'object entity'
-				SetDataProperties(entity);
-			}
-		}
-
-		/// <summary>
-		/// MR:- not sure I need this??
-		/// </summary>
-		/// <param name="nextPage"></param>
-		/// <param name="appId"></param>
-		private void SetCommonViewDataProperties(string nextPage, int appId)
-		{
-			ViewData[FieldConstants.CurrentPage] = nextPage;
-			ViewData[FieldConstants.SipApplicationId] = appId;
-		}
-
-		/// <summary>
-		/// Sets the ViewData[] with the returned view properties
-		/// </summary>
-		/// <param name="entity">e.g. school object</param>
-		private void SetDataProperties(object? entity)
-		{
-			// MR:- get a dictionary / array / list of view property keys
-			var viewProperties = GetViewFieldProperties();
-			if (!viewProperties.Any())
-			{
-				return;
-			}
-
-			// TODO MR:- hacked this about, might not work !!
-			var data = entity.GetType()
-				.GetProperties()
-				.ToDictionary(property => property.Name, property => property.GetValue(entity));
-
-			// populate the ViewData[] value from the entity object
-			foreach (KeyValuePair<string, string> field in viewProperties)
-			{
-				var fieldName = field.Value; // property name
-
-				if (data.ContainsKey(fieldName))
-				{
-					ViewData[field.Key] = data[fieldName] switch
-					{
-						DateTime dateTime => dateTime.ToString(CultureInfo.CurrentCulture),
-						object obj => obj.ToString(),
-						_ => string.Empty
-					};
-				}
-				else
-				{
-					ViewData[field.Key] = string.Empty;
-				}
-			}
-		}
-
-		/// <summary>
-		/// Get a list / dictionary / array of view / field names. 
-		/// This MUST match the property names of the object you're searching / matching
-		/// within SetDataProperties()
-		/// </summary>
-		/// <returns></returns>
-		private Dictionary<string, string> GetViewFieldProperties()
-		{
-			// add keys into dictionary representing conversion date properties / data
-			// what are consumed by govuk-date tag helper
-			Dictionary<string, string> viewFields = new()
-			{
-				{ FieldConstants.SipSchoolConversionTargetDateExplained, "SchoolConversionTargetDateExplained" },
-
-				{ FieldConstants.SipSchoolConversionTargetDateDate, "SchoolConversionTargetDate" },
-
-				// FieldConstants.SipSchoolConversionTargetDateDifferent - NOT in SchoolApplyingToConvert
-				// as NOT in API
-				{ FieldConstants.SipSchoolConversionTargetDateDifferent, "" },
-
-				// MR:- setting up 3 below as consumed by govuk-date tag helper
-				// value for below will be 'dd' component of "SchoolConversionTargetDate"
-				{ $"{FieldConstants.SipSchoolConversionTargetDateDate} - day", "" },
-
-				// value for below will be 'MM' component of "SchoolConversionTargetDate"
-				{ $"{FieldConstants.SipSchoolConversionTargetDateDate} - month", "" },
-
-				// value for below will be 'yyyy' component of "SchoolConversionTargetDate"
-				{ $"{FieldConstants.SipSchoolConversionTargetDateDate} - year", "" }
-			};
-
-			return viewFields;
-		}
-	}
+    }
 }

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
@@ -5,6 +5,7 @@ using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
 using Microsoft.AspNetCore.Mvc;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 
 namespace Dfe.Academies.External.Web.Pages.School
 {
@@ -194,8 +195,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			if (appId == 0)
 			{
-				// create viewData[] pointers for each property within 'object entity'
-				SetDataProperties(nextPage, entity);
+				// create ViewData[] pointers for each property within 'object entity'
+				SetDataProperties(entity);
 			}
 		}
 
@@ -206,11 +207,10 @@ namespace Dfe.Academies.External.Web.Pages.School
 		}
 
 		/// <summary>
-		/// Sets the ViewData with the returned view properties
+		/// Sets the ViewData[] with the returned view properties
 		/// </summary>
-		/// <param name="nextPage"></param>
 		/// <param name="entity">e.g. school object</param>
-		private void SetDataProperties(string nextPage, object entity)
+		private void SetDataProperties(object entity)
 		{
 			// MR:- get a dictionary / array / list of view property keys
 			// to then populate the value from the entity object
@@ -233,7 +233,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 				{
 					ViewData[field.Key] = data[fieldName] switch
 					{
-						DateTime dateTime => dateTime.ToString(),
+						DateTime dateTime => dateTime.ToString(CultureInfo.CurrentCulture),
 						object obj => obj.ToString(),
 						_ => string.Empty
 					};
@@ -253,21 +253,28 @@ namespace Dfe.Academies.External.Web.Pages.School
 		/// <returns></returns>
 		private Dictionary<string, string> GetViewFieldProperties()
 		{
-			Dictionary<string, string> viewFields = new Dictionary<string, string>();
+			// add keys into dictionary representing conversion date properties / data
+			// what are consumed by govuk-date tag helper
+			Dictionary<string, string> viewFields = new()
+			{
+				{ FieldConstants.SipSchoolConversionTargetDateExplained, "SchoolConversionTargetDateExplained" },
 
-			// add 3 keys to dictionary representing conversion date properties / data
-			//FieldConstants.SipSchoolConversionTargetDateExplained
-			viewFields.Add(FieldConstants.SipSchoolConversionTargetDateExplained, "SchoolConversionTargetDateExplained");
+				{ FieldConstants.SipSchoolConversionTargetDateDate, "SchoolConversionTargetDate" },
 
-			//FieldConstants.SipSchoolConversionTargetDateDate = SchoolConversionTargetDate
-			viewFields.Add(FieldConstants.SipSchoolConversionTargetDateDate, "SchoolConversionTargetDate");
+				// FieldConstants.SipSchoolConversionTargetDateDifferent - NOT in SchoolApplyingToConvert
+				// as NOT in API
+				{ FieldConstants.SipSchoolConversionTargetDateDifferent, "" },
 
-			//FieldConstants.SipSchoolConversionTargetDateDifferent
-			viewFields.Add(FieldConstants.SipSchoolConversionTargetDateDifferent, "");
+				// MR:- setting up 3 below as consumed by govuk-date tag helper
+				// value for below will be 'dd' component of "SchoolConversionTargetDate"
+				{ $"{FieldConstants.SipSchoolConversionTargetDateDate} - day", "" },
 
-			//field - day = "@ViewData[FieldConstants.SipSchoolConversionTargetDateDate + " - day"]"
-			//field - month = "@ViewData[FieldConstants.SipSchoolConversionTargetDateDate + " - month"]"
-			//field - year = "@ViewData[FieldConstants.SipSchoolConversionTargetDateDate + " - year"]" >
+				// value for below will be 'MM' component of "SchoolConversionTargetDate"
+				{ $"{FieldConstants.SipSchoolConversionTargetDateDate} - month", "" },
+
+				// value for below will be 'yyyy' component of "SchoolConversionTargetDate"
+				{ $"{FieldConstants.SipSchoolConversionTargetDateDate} - year", "" }
+			};
 
 			return viewFields;
 		}

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
@@ -1,11 +1,9 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using System.Globalization;
 using Dfe.Academies.External.Web.Enums;
 using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Primitives;
 
 namespace Dfe.Academies.External.Web.Pages.School
 {
@@ -141,6 +139,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 			{
 				ModelState.AddModelError("SchoolConversionTargetDateNotEntered", "You must select a conversion date");
 				PopulateValidationMessages();
+				//TargetDate = $"{day}/{month}/{year}"; // MR:- CAN'T set this in this scenario as taghelper expects REAL datetime, not invalid one
 				TargetDateDay = day;
 				TargetDateMonth = month;
 				TargetDateYear = year;
@@ -151,9 +150,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 			{
 				ModelState.AddModelError("TargetDateExplainedNotEntered", "You must explain why you want to convert on this date");
 				PopulateValidationMessages();
-				TargetDateDay = day;
-				TargetDateMonth = month;
-				TargetDateYear = year;
 				return Page();
 			}
 

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
@@ -182,15 +182,17 @@ namespace Dfe.Academies.External.Web.Pages.School
 			//TargetDateExplained = ;
 		}
 
-		private void SetSchoolViewData(int appId, SchoolApplyingToConvert? school, string view)
+		private void SetSchoolViewData(int appId, SchoolApplyingToConvert? school, string viewName)
 		{
-			SetViewDataProperties(appId, view, school);
+			SetViewDataProperties(appId, viewName, school);
 
+			// MR:- not sure I need this??
 			ViewData[FieldConstants.SipApplyingSchoolsId] = school.URN;
 		}
 
-		private void SetViewDataProperties(int appId, string nextPage, object entity)
+		private void SetViewDataProperties(int appId, string nextPage, object? entity)
 		{
+			// MR:- not sure I need this??
 			SetCommonViewDataProperties(nextPage, appId);
 
 			if (appId == 0)
@@ -200,6 +202,11 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		/// <summary>
+		/// MR:- not sure I need this??
+		/// </summary>
+		/// <param name="nextPage"></param>
+		/// <param name="appId"></param>
 		private void SetCommonViewDataProperties(string nextPage, int appId)
 		{
 			ViewData[FieldConstants.CurrentPage] = nextPage;
@@ -210,10 +217,9 @@ namespace Dfe.Academies.External.Web.Pages.School
 		/// Sets the ViewData[] with the returned view properties
 		/// </summary>
 		/// <param name="entity">e.g. school object</param>
-		private void SetDataProperties(object entity)
+		private void SetDataProperties(object? entity)
 		{
 			// MR:- get a dictionary / array / list of view property keys
-			// to then populate the value from the entity object
 			var viewProperties = GetViewFieldProperties();
 			if (!viewProperties.Any())
 			{
@@ -225,6 +231,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 				.GetProperties()
 				.ToDictionary(property => property.Name, property => property.GetValue(entity));
 
+			// populate the ViewData[] value from the entity object
 			foreach (KeyValuePair<string, string> field in viewProperties)
 			{
 				var fieldName = field.Value; // property name

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
@@ -137,7 +137,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 				return Page();
 			}
 
-			if (TargetDateDifferent == SelectOption.Yes && targetDate != DateTime.MinValue)
+			if (TargetDateDifferent == SelectOption.Yes && targetDate == DateTime.MinValue)
 			{
 				ModelState.AddModelError("SchoolConversionTargetDateNotEntered", "You must select a conversion date");
 				PopulateValidationMessages();

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Globalization;
-using Dfe.Academies.External.Web.Constants;
 using Dfe.Academies.External.Web.Enums;
 using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
@@ -15,6 +14,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 	    private readonly ILogger<ApplicationConversionTargetDateModel> _logger;
 	    private readonly IConversionApplicationCreationService _academisationCreationService;
 	    private const string NextStepPage = "ApplicationJoinTrustReasons";
+	    public string SchoolConversionTargetDateDate = "sip_ctddiferentdatevalue";
 
 		//// MR:- selected school props for UI rendering
 		[BindProperty]
@@ -112,10 +112,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 					PopulateUiModel(selectedSchool);
 				}
-
-				// MR:- code from a2c-sip for date picker - set up ViewData[] dictionary with object values in it
-				// string newView = "ConversionTargetDate";
-				// SetSchoolViewData(appId, selectedSchool, newView);
 			}
 			catch (Exception ex)
 			{
@@ -126,12 +122,14 @@ namespace Dfe.Academies.External.Web.Pages.School
 		public async Task<IActionResult> OnPostAsync(IFormCollection form)
 		{
 			//var id = Convert.ToInt32(form["ApplicationId"]);
-			form.TryGetValue($"{FieldConstants.SipSchoolConversionTargetDateDate}-day", out StringValues day);
-			form.TryGetValue($"{FieldConstants.SipSchoolConversionTargetDateDate}-month", out StringValues month);
-			form.TryGetValue($"{FieldConstants.SipSchoolConversionTargetDateDate}-year", out StringValues year);
 
 			// MR:- try and build a date from component parts !!!
-			var targetDate = BuildDateTime(day,month,year);
+			var dateComponents = RetrieveDateTimeComponentsFromDatePicker(form, SchoolConversionTargetDateDate);
+			var day = dateComponents.FirstOrDefault(x => x.Key == "day").Value;
+			var month = dateComponents.FirstOrDefault(x => x.Key == "month").Value;
+			var year = dateComponents.FirstOrDefault(x => x.Key == "year").Value;
+
+			var targetDate = BuildDateTime(day, month, year);
 
 			if (!ModelState.IsValid)
 			{
@@ -139,11 +137,13 @@ namespace Dfe.Academies.External.Web.Pages.School
 				return Page();
 			}
 
-			if ((TargetDateDifferent == SelectOption.Yes && !targetDate.HasValue) 
-			    || (TargetDateDifferent == SelectOption.Yes && targetDate.HasValue && targetDate.Value == DateTime.MinValue))
+			if (TargetDateDifferent == SelectOption.Yes && targetDate != DateTime.MinValue)
 			{
 				ModelState.AddModelError("SchoolConversionTargetDateNotEntered", "You must select a conversion date");
 				PopulateValidationMessages();
+				TargetDateDay = day;
+				TargetDateMonth = month;
+				TargetDateYear = year;
 				return Page();
 			}
 
@@ -151,6 +151,9 @@ namespace Dfe.Academies.External.Web.Pages.School
 			{
 				ModelState.AddModelError("TargetDateExplainedNotEntered", "You must explain why you want to convert on this date");
 				PopulateValidationMessages();
+				TargetDateDay = day;
+				TargetDateMonth = month;
+				TargetDateYear = year;
 				return Page();
 			}
 
@@ -160,7 +163,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 				var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
 				// TODO MR:- call API endpoint to log data
-				// await _academisationCreationService.UpdateSchoolConversionDate(TargetDate, TargetDateExplained);
+				// await _academisationCreationService.UpdateSchoolConversionDate(targetDate, TargetDateExplained);
 
 				// update temp store for next step
 				TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
@@ -187,123 +190,9 @@ namespace Dfe.Academies.External.Web.Pages.School
 		{
 			SchoolName = selectedSchool.SchoolName;
 			// TODO MR:- bind below from API data
-			// TargetDateDifferent = selectedSchool.;
-			// TargetDate = selectedSchool.;
-			// TargetDateExplained = selectedSchool.;
+			// TargetDateDifferent = selectedSchool.; // MR:- not implemented in API 01/09/2022 
+			// TargetDate = selectedSchool.SchoolConversionTargetDate;
+			// TargetDateExplained = selectedSchool.SchoolConversionTargetDateExplained;
 		}
-
-		//private void SetSchoolViewData(int appId, SchoolApplyingToConvert? school, string viewName)
-		//{
-		//	SetViewDataProperties(appId, viewName, school);
-
-		//	// MR:- not sure I need this??
-		//	ViewData[FieldConstants.SipApplyingSchoolsId] = school.URN;
-		//}
-
-		//private void SetViewDataProperties(int appId, string nextPage, object? entity)
-		//{
-		//	// MR:- not sure I need this??
-		//	SetCommonViewDataProperties(nextPage, appId);
-
-		//	if (appId != 0)
-		//	{
-		//		// create ViewData[] pointers for each property within 'object entity'
-		//		SetDataProperties(entity);
-		//	}
-		//}
-
-		///// <summary>
-		///// MR:- not sure I need this??
-		///// </summary>
-		///// <param name="nextPage"></param>
-		///// <param name="appId"></param>
-		//private void SetCommonViewDataProperties(string nextPage, int appId)
-		//{
-		//	ViewData[FieldConstants.CurrentPage] = nextPage;
-		//	ViewData[FieldConstants.SipApplicationId] = appId;
-		//}
-
-		///// <summary>
-		///// Sets the ViewData[] with the returned view properties
-		///// </summary>
-		///// <param name="entity">e.g. school object</param>
-		//private void SetDataProperties(object? entity)
-		//{
-		//	// MR:- get a dictionary / array / list of view property keys
-		//	var viewProperties = GetViewFieldProperties();
-		//	if (!viewProperties.Any())
-		//	{
-		//		return;
-		//	}
-
-		//	var data = entity.GetType()
-		//		.GetProperties()
-		//		.ToDictionary(property => property.Name, property => property.GetValue(entity));
-
-		//	// populate the ViewData[] value from the entity object
-		//	foreach (KeyValuePair<string, string> field in viewProperties)
-		//	{
-		//		var fieldName = field.Value; // property name
-
-		//		if (data.ContainsKey(fieldName))
-		//		{
-		//			ViewData[field.Key] = data[fieldName] switch
-		//			{
-		//				DateTime dateTime => dateTime.ToString(CultureInfo.CurrentCulture),
-		//				object obj => obj.ToString(),
-		//				_ => string.Empty
-		//			};
-		//		}
-		//		else
-		//		{
-		//			ViewData[field.Key] = string.Empty;
-		//		}
-		//	}
-		//}
-
-		///// <summary>
-		///// Get a list / dictionary / array of view / field names. 
-		///// This MUST match the property names of the object you're searching / matching
-		///// within SetDataProperties()
-		///// </summary>
-		///// <returns></returns>
-		//private Dictionary<string, string> GetViewFieldProperties()
-		//{
-		//	// add keys into dictionary representing conversion date properties / data
-		//	// what are consumed by govuk-date tag helper
-		//	Dictionary<string, string> viewFields = new()
-		//	{
-		//		{ FieldConstants.SipSchoolConversionTargetDateExplained, "SchoolConversionTargetDateExplained" },
-
-		//		{ FieldConstants.SipSchoolConversionTargetDateDate, "SchoolConversionTargetDate" },
-
-		//		// FieldConstants.SipSchoolConversionTargetDateDifferent - NOT in SchoolApplyingToConvert
-		//		// as NOT in API
-		//		{ FieldConstants.SipSchoolConversionTargetDateDifferent, "" },
-
-		//		// MR:- setting up 3 below as consumed by govuk-date tag helper
-		//		// value for below will be 'dd' component of "SchoolConversionTargetDate"
-		//		{ $"{FieldConstants.SipSchoolConversionTargetDateDate}-day", "" },
-
-		//		// value for below will be 'MM' component of "SchoolConversionTargetDate"
-		//		{ $"{FieldConstants.SipSchoolConversionTargetDateDate}-month", "" },
-
-		//		// value for below will be 'yyyy' component of "SchoolConversionTargetDate"
-		//		{ $"{FieldConstants.SipSchoolConversionTargetDateDate}-year", "" }
-		//	};
-
-		//	return viewFields;
-		//}
-
-		public DateTime? BuildDateTime(string day, string month, string year)
-		{
-			string dateString = $"{day}/{month}/{year}"; 
-			string format = "dd/MM/yyyy";
-			
-			DateTime.TryParseExact(dateString, format, CultureInfo.InvariantCulture,
-				DateTimeStyles.None, out DateTime newDate);
-
-			return newDate;
-		}
-    }
+	}
 }

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
@@ -140,7 +140,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 
 			if ((TargetDateDifferent == SelectOption.Yes && !targetDate.HasValue) 
-			    || (TargetDateDifferent == SelectOption.Yes && targetDate.HasValue && targetDate.Value != DateTime.MinValue))
+			    || (TargetDateDifferent == SelectOption.Yes && targetDate.HasValue && targetDate.Value == DateTime.MinValue))
 			{
 				ModelState.AddModelError("SchoolConversionTargetDateNotEntered", "You must select a conversion date");
 				PopulateValidationMessages();


### PR DESCRIPTION
Fix bespoke datepicker data binding issues & getting values on post

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
<!--- Tell us what should happen: -->
<!--- * If a new feature then briefly explain what has been added -->
<!--- * If a bug fix briefly explain what should be happening that isn't -->
<!--- * If a breaking change then briefly explain what is changing -->

## Steps to reproduce issue (if relevant)
1. When submitting conversion target date page, the target date input got lost
2. Also, if an incorrect data was submitted this was lost on submit

## Steps to test this PR
run Unit tests - as change made to resilient request provider - although CI / CD does this for you
Test application by:-
a) log in
b) go into an existing application from the pending applications section
c) click 'about the conversion' on application overview page
d) click 'start section' on date for conversion on school overview page
e) select 'yes', input an incorrect data e.g. 30/02/2022 and a reason
f) press 'save and return to overview'
g) you will receive a  validation warning, but, the date will be re-populated

## Prerequisites
n/a
