### PR TITLE
105405 datepicker fix land and buildings page

### DIFF
--- a/Dfe.Academies.External.Web.UnitTest/Pages/School/LandAndBuildingsModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Pages/School/LandAndBuildingsModelTests.cs
@@ -1,15 +1,16 @@
-﻿using Dfe.Academies.External.Web.Pages.School;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dfe.Academies.External.Web.Pages.School;
 using Dfe.Academies.External.Web.Services;
 using Dfe.Academies.External.Web.UnitTest.Factories;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
-using System.Threading.Tasks;
-using System.Collections.Generic;
 
 namespace Dfe.Academies.External.Web.UnitTest.Pages.School;
 
@@ -58,6 +59,7 @@ internal sealed class LandAndBuildingsModelTests
 		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
 		var mockLogger = new Mock<ILogger<LandAndBuildingsModel>>();
 		var expectedErrorText = "You must provide details";
+		var mockForm = new Mock<IFormCollection>();
 
 		var pageModel = SetupLandAndBuildingsModel(mockLogger.Object,
 			mockConversionApplicationCreationService.Object,
@@ -67,7 +69,7 @@ internal sealed class LandAndBuildingsModelTests
 		pageModel.ModelState.AddModelError("SchoolBuildLandWorksPlannedExplainedNotEntered", expectedErrorText);
 
 		// act
-		await pageModel.OnPostAsync();
+		await pageModel.OnPostAsync(mockForm.Object);
 
 		Dictionary<string, IEnumerable<string>?> errors = (Dictionary<string, IEnumerable<string>?>)pageModel.ViewData["Errors"]!;
 
@@ -85,6 +87,7 @@ internal sealed class LandAndBuildingsModelTests
 		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
 		var mockLogger = new Mock<ILogger<LandAndBuildingsModel>>();
 		var expectedErrorText = "You must provide details";
+		var mockForm = new Mock<IFormCollection>();
 
 		var pageModel = SetupLandAndBuildingsModel(mockLogger.Object,
 			mockConversionApplicationCreationService.Object,
@@ -94,7 +97,7 @@ internal sealed class LandAndBuildingsModelTests
 		pageModel.ModelState.AddModelError("SchoolBuildLandWorksPlannedDateNotEntered", expectedErrorText);
 
 		// act
-		await pageModel.OnPostAsync();
+		await pageModel.OnPostAsync(mockForm.Object);
 
 		Dictionary<string, IEnumerable<string>?> errors = (Dictionary<string, IEnumerable<string>?>)pageModel.ViewData["Errors"]!;
 
@@ -112,6 +115,7 @@ internal sealed class LandAndBuildingsModelTests
 		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
 		var mockLogger = new Mock<ILogger<LandAndBuildingsModel>>();
 		var expectedErrorText = "You must provide details";
+		var mockForm = new Mock<IFormCollection>();
 
 		var pageModel = SetupLandAndBuildingsModel(mockLogger.Object,
 			mockConversionApplicationCreationService.Object,
@@ -121,7 +125,7 @@ internal sealed class LandAndBuildingsModelTests
 		pageModel.ModelState.AddModelError("SchoolBuildLandSharedFacilitiesExplainedNotEntered", expectedErrorText);
 
 		// act
-		await pageModel.OnPostAsync();
+		await pageModel.OnPostAsync(mockForm.Object);
 
 		Dictionary<string, IEnumerable<string>?> errors = (Dictionary<string, IEnumerable<string>?>)pageModel.ViewData["Errors"]!;
 
@@ -139,6 +143,7 @@ internal sealed class LandAndBuildingsModelTests
 		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
 		var mockLogger = new Mock<ILogger<LandAndBuildingsModel>>();
 		var expectedErrorText = "You must provide details";
+		var mockForm = new Mock<IFormCollection>();
 
 		var pageModel = SetupLandAndBuildingsModel(mockLogger.Object,
 			mockConversionApplicationCreationService.Object,
@@ -148,7 +153,7 @@ internal sealed class LandAndBuildingsModelTests
 		pageModel.ModelState.AddModelError("SchoolBuildLandGrantsBodiesNotEntered", expectedErrorText);
 
 		// act
-		await pageModel.OnPostAsync();
+		await pageModel.OnPostAsync(mockForm.Object);
 
 		Dictionary<string, IEnumerable<string>?> errors = (Dictionary<string, IEnumerable<string>?>)pageModel.ViewData["Errors"]!;
 
@@ -166,6 +171,7 @@ internal sealed class LandAndBuildingsModelTests
 		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
 		var mockLogger = new Mock<ILogger<LandAndBuildingsModel>>();
 		var expectedErrorText = "You must provide details";
+		var mockForm = new Mock<IFormCollection>();
 
 		var pageModel = SetupLandAndBuildingsModel(mockLogger.Object,
 			mockConversionApplicationCreationService.Object,
@@ -175,7 +181,7 @@ internal sealed class LandAndBuildingsModelTests
 		pageModel.ModelState.AddModelError("SchoolBuildLandPFISchemeTypeNotEntered", expectedErrorText);
 
 		// act
-		await pageModel.OnPostAsync();
+		await pageModel.OnPostAsync(mockForm.Object);
 
 		Dictionary<string, IEnumerable<string>?> errors = (Dictionary<string, IEnumerable<string>?>)pageModel.ViewData["Errors"]!;
 
@@ -193,6 +199,7 @@ internal sealed class LandAndBuildingsModelTests
 		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
 		var mockLogger = new Mock<ILogger<LandAndBuildingsModel>>();
 		var expectedErrorText = "You must provide details";
+		var mockForm = new Mock<IFormCollection>();
 
 		var pageModel = SetupLandAndBuildingsModel(mockLogger.Object,
 			mockConversionApplicationCreationService.Object,
@@ -202,7 +209,7 @@ internal sealed class LandAndBuildingsModelTests
 		pageModel.ModelState.AddModelError("SchoolBuildLandWorksPlannedExplainedNotEntered", expectedErrorText);
 
 		// act
-		await pageModel.OnPostAsync();
+		await pageModel.OnPostAsync(mockForm.Object);
 
 		Dictionary<string, IEnumerable<string>?> errors = (Dictionary<string, IEnumerable<string>?>)pageModel.ViewData["Errors"]!;
 
@@ -220,6 +227,7 @@ internal sealed class LandAndBuildingsModelTests
 		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
 		var mockLogger = new Mock<ILogger<LandAndBuildingsModel>>();
 		var expectedErrorText = "You must provide details";
+		var mockForm = new Mock<IFormCollection>();
 
 		var pageModel = SetupLandAndBuildingsModel(mockLogger.Object,
 			mockConversionApplicationCreationService.Object,
@@ -229,7 +237,7 @@ internal sealed class LandAndBuildingsModelTests
 		pageModel.ModelState.AddModelError("SchoolBuildLandWorksPlannedDateNotEntered", expectedErrorText);
 
 		// act
-		await pageModel.OnPostAsync();
+		await pageModel.OnPostAsync(mockForm.Object);
 
 		Dictionary<string, IEnumerable<string>?> errors = (Dictionary<string, IEnumerable<string>?>)pageModel.ViewData["Errors"]!;
 
@@ -247,6 +255,7 @@ internal sealed class LandAndBuildingsModelTests
 		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
 		var mockLogger = new Mock<ILogger<LandAndBuildingsModel>>();
 		var expectedErrorText = "You must provide details";
+		var mockForm = new Mock<IFormCollection>();
 
 		var pageModel = SetupLandAndBuildingsModel(mockLogger.Object,
 			mockConversionApplicationCreationService.Object,
@@ -256,7 +265,7 @@ internal sealed class LandAndBuildingsModelTests
 		pageModel.ModelState.AddModelError("SchoolBuildLandSharedFacilitiesExplainedNotEntered", expectedErrorText);
 
 		// act
-		await pageModel.OnPostAsync();
+		await pageModel.OnPostAsync(mockForm.Object);
 
 		Dictionary<string, IEnumerable<string>?> errors = (Dictionary<string, IEnumerable<string>?>)pageModel.ViewData["Errors"]!;
 
@@ -274,6 +283,7 @@ internal sealed class LandAndBuildingsModelTests
 		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
 		var mockLogger = new Mock<ILogger<LandAndBuildingsModel>>();
 		var expectedErrorText = "You must provide details";
+		var mockForm = new Mock<IFormCollection>();
 
 		var pageModel = SetupLandAndBuildingsModel(mockLogger.Object,
 			mockConversionApplicationCreationService.Object,
@@ -283,7 +293,7 @@ internal sealed class LandAndBuildingsModelTests
 		pageModel.ModelState.AddModelError("SchoolBuildLandGrantsBodiesNotEntered", expectedErrorText);
 
 		// act
-		await pageModel.OnPostAsync();
+		await pageModel.OnPostAsync(mockForm.Object);
 
 		Dictionary<string, IEnumerable<string>?> errors = (Dictionary<string, IEnumerable<string>?>)pageModel.ViewData["Errors"]!;
 
@@ -301,6 +311,7 @@ internal sealed class LandAndBuildingsModelTests
 		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
 		var mockLogger = new Mock<ILogger<LandAndBuildingsModel>>();
 		var expectedErrorText = "You must provide details";
+		var mockForm = new Mock<IFormCollection>();
 
 		var pageModel = SetupLandAndBuildingsModel(mockLogger.Object,
 			mockConversionApplicationCreationService.Object,
@@ -310,7 +321,7 @@ internal sealed class LandAndBuildingsModelTests
 		pageModel.ModelState.AddModelError("SchoolBuildLandPFISchemeTypeNotEntered", expectedErrorText);
 
 		// act
-		await pageModel.OnPostAsync();
+		await pageModel.OnPostAsync(mockForm.Object);
 
 		Dictionary<string, IEnumerable<string>?> errors = (Dictionary<string, IEnumerable<string>?>)pageModel.ViewData["Errors"]!;
 

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
@@ -106,8 +106,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 				// Grab other values from API
 				if (selectedSchool != null)
 				{
-					// TODO MR:- awaiting PR 114
-
 					PopulateUiModel(selectedSchool);
 				}
 			}

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml
@@ -80,8 +80,8 @@
 										   class="@(Model.SchoolBuildLandWorksPlannedDateError ? "govuk-error-message" : "govuk-visually-hidden")">
 											You must select a scheduled date
 										</a>
-										<govuk-date field-name="SchoolBuildLandWorksPlannedDate"
-										            field-data="@Model.SchoolBuildLandWorksPlannedDate"
+										<govuk-date field-name="@Model.PlannedDateFormInputName"
+										            field-data="@Model.WorksPlannedDate"
 										            field-day="@Model.WorksPlannedDateDay"
 										            field-month="@Model.WorksPlannedDateMonth"
 										            field-year="@Model.WorksPlannedDateYear">

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
@@ -69,59 +69,94 @@ namespace Dfe.Academies.External.Web.Pages.School
 				selectedSchool.LandAndBuildings.OwnerExplained ?? "Not entered")
 			);
 
-			heading1.Sections.Add(new(SchoolLandAndBuildingsSummarySectionViewModel.PlannedBuildingWorks, selectedSchool.LandAndBuildings.WorksPlanned.Value ? "Yes" : "No")
+			heading1.Sections.Add(new(
+				SchoolLandAndBuildingsSummarySectionViewModel.PlannedBuildingWorks,
+				(selectedSchool.LandAndBuildings.WorksPlanned.HasValue ?
+					"Yes" :
+					"No")
+				)
 			{
 				SubQuestionAndAnswers = new()
 				{
 					new SchoolLandAndBuildingsSummarySectionViewModel(
 						SchoolLandAndBuildingsSummarySectionViewModel.PlannedBuildingWorksDetails,
-						selectedSchool.LandAndBuildings.WorksPlannedExplained ?? "Not entered"
+						(!string.IsNullOrWhiteSpace(selectedSchool.LandAndBuildings.WorksPlannedExplained) ?
+							selectedSchool.LandAndBuildings.WorksPlannedExplained : 
+							QuestionAndAnswerConstants.NoAnswer)
 					),
 					new SchoolLandAndBuildingsSummarySectionViewModel(
 						SchoolLandAndBuildingsSummarySectionViewModel.PlannedBuildingWorksWhen,
-						selectedSchool.LandAndBuildings.WorksPlannedDate.ToString() ?? "Not entered"
+						(selectedSchool.LandAndBuildings.WorksPlannedDate.HasValue ?
+							selectedSchool.LandAndBuildings.WorksPlannedDate.Value.ToString("dd/MM/yyyy") : 
+							QuestionAndAnswerConstants.NoAnswer)
 					)
 				}
 			});
 
-			heading1.Sections.Add(new(SchoolLandAndBuildingsSummarySectionViewModel.SharedFacilities, selectedSchool.LandAndBuildings.FacilitiesShared.Value ? "Yes" : "No")
+			heading1.Sections.Add(new(
+				SchoolLandAndBuildingsSummarySectionViewModel.SharedFacilities,
+				(selectedSchool.LandAndBuildings.FacilitiesShared.HasValue ?
+					"Yes" :
+					"No")
+			)
 			{
 				SubQuestionAndAnswers = new()
 				{
 					new SchoolLandAndBuildingsSummarySectionViewModel(
 						SchoolLandAndBuildingsSummarySectionViewModel.SharedFacilitiesList,
-						selectedSchool.LandAndBuildings.FacilitiesSharedExplained ?? "Not entered"
+						selectedSchool.LandAndBuildings.FacilitiesSharedExplained ??
+						QuestionAndAnswerConstants.NoAnswer
 					)
 				}
 			});
 
-			heading1.Sections.Add(new(SchoolLandAndBuildingsSummarySectionViewModel.Grants, selectedSchool.LandAndBuildings.Grants.Value ? "Yes" : "No")
-			{
+			heading1.Sections.Add(new(
+				SchoolLandAndBuildingsSummarySectionViewModel.Grants,
+				(selectedSchool.LandAndBuildings.Grants.HasValue ?
+					"Yes" :
+					"No")
+				)
+				{
 				SubQuestionAndAnswers = new()
 				{
 					new SchoolLandAndBuildingsSummarySectionViewModel(
 						SchoolLandAndBuildingsSummarySectionViewModel.GrantBodies, 
-						selectedSchool.LandAndBuildings.GrantsAwardingBodies ?? "Not entered"
+						selectedSchool.LandAndBuildings.GrantsAwardingBodies ??
+						QuestionAndAnswerConstants.NoAnswer
 					)
 				}
 			});
 
-			heading1.Sections.Add(new(SchoolLandAndBuildingsSummarySectionViewModel.PFI, selectedSchool.LandAndBuildings.PartOfPFIScheme.Value ? "Yes" : "No")
-			{
+			heading1.Sections.Add(new(
+				SchoolLandAndBuildingsSummarySectionViewModel.PFI,
+				(selectedSchool.LandAndBuildings.PartOfPFIScheme.HasValue ?
+					"Yes" :
+					"No")
+				)
+				{
 				SubQuestionAndAnswers = new()
 				{
 					new SchoolLandAndBuildingsSummarySectionViewModel(
 						SchoolLandAndBuildingsSummarySectionViewModel.PFIKind,
-						selectedSchool.LandAndBuildings.PartOfPFISchemeType ?? "Not entered")
+						selectedSchool.LandAndBuildings.PartOfPFISchemeType ??
+						QuestionAndAnswerConstants.NoAnswer)
 				}
 			});
 
-			heading1.Sections.Add(new(SchoolLandAndBuildingsSummarySectionViewModel.PrioritySchoolBuildingProgram,
-				selectedSchool.LandAndBuildings.PartOfPrioritySchoolsBuildingProgramme.Value ? "Yes" : "No")
+			heading1.Sections.Add(new(
+				SchoolLandAndBuildingsSummarySectionViewModel.PrioritySchoolBuildingProgram,
+				(selectedSchool.LandAndBuildings.PartOfPrioritySchoolsBuildingProgramme.HasValue ?
+					"Yes" :
+					"No")
+				)
 			);
 
-			heading1.Sections.Add(new(SchoolLandAndBuildingsSummarySectionViewModel.BuildingSchoolsForTheFuture, 
-				selectedSchool.LandAndBuildings.PartOfBuildingSchoolsForFutureProgramme.Value ? "Yes" : "No")
+			heading1.Sections.Add(new(
+				SchoolLandAndBuildingsSummarySectionViewModel.BuildingSchoolsForTheFuture,
+				(selectedSchool.LandAndBuildings.PartOfBuildingSchoolsForFutureProgramme.HasValue ?
+					"Yes" :
+					"No")
+				)
 			);
 
 			var vm = new List<SchoolLandAndBuildingsSummaryHeadingViewModel> { heading1 };

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using Dfe.Academies.External.Web.Models;
+﻿using Dfe.Academies.External.Web.Enums;
+using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
 using Dfe.Academies.External.Web.ViewModels;
@@ -62,8 +63,12 @@ namespace Dfe.Academies.External.Web.Pages.School
 			SchoolName = selectedSchool.SchoolName;
 
 			SchoolLandAndBuildingsSummaryHeadingViewModel heading1 = new(SchoolLandAndBuildingsSummaryHeadingViewModel.Heading,
-				"/school/LandAndBuildings");
-			
+				"/school/LandAndBuildings")
+			{
+				Status = selectedSchool.LandAndBuildings.WorksPlanned.HasValue ?
+					SchoolConversionComponentStatus.Complete
+					: SchoolConversionComponentStatus.NotStarted
+			};
 
 			heading1.Sections.Add(new(SchoolLandAndBuildingsSummarySectionViewModel.LandOwnership,
 				selectedSchool.LandAndBuildings.OwnerExplained ?? "Not entered")

--- a/Dfe.Academies.External.Web/ViewModels/QuestionAndAnswerConstants.cs
+++ b/Dfe.Academies.External.Web/ViewModels/QuestionAndAnswerConstants.cs
@@ -3,4 +3,5 @@
 public static class QuestionAndAnswerConstants
 {
 	public const string NoInfoAnswer = "You have not added any information";
+	public const string NoAnswer = "Not Entered";
 }


### PR DESCRIPTION
<!--- Link to issue this PR resolves -->
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/105405?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
If input incorrect Works Planned Date validation error shown and incorrect date kept

## Steps to reproduce issue (if relevant)
1. When submitting Works Planned Date page, the date input value got lost
2. Also, if an incorrect data was submitted this was lost on submit
3. Also fixed land & buildings summary page bug when no land & building data existed against application
4. Also, set status of 'Heading' on land & buildings summary page

## Steps to test this PR
1) run Unit tests - as change made to resilient request provider - although CI / CD does this for you
2) Test application by:-
a) log in
b) go into an existing application from the pending applications section
c) click 'land and buildings' on application overview page
d) click 'start section' on date for conversion on school overview page
e) select 'yes' on 'any current or planned building works?', input an incorrect data e.g. 30/02/2022 and a reason
f) press 'save and return to overview'
g) you will receive a validation warning, but, the date will be re-populated

## Prerequisites
n/a
