### PR TITLE
106008 missing text land and buildings

### DIFF
--- a/Dfe.Academies.External.Web/Enums/AcademisationWorkflowEnums.cs
+++ b/Dfe.Academies.External.Web/Enums/AcademisationWorkflowEnums.cs
@@ -90,3 +90,10 @@ public enum ApplicationStatus
 	[Description("Submitted")]
 	Submitted
 }
+
+public enum EqualityImpact
+{
+	ConsideredUnlikely,
+	ConsideredWillNot,
+	NotConsidered
+}

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
@@ -23,7 +23,7 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 
 	//// MR:- VM props to capture data
 	[BindProperty]
-	[RequiredEnum(ErrorMessage = "You must provide details")]
+	[RequiredEnum(ErrorMessage = "You must choose an option")]
 	public SelectOption SchoolConsultationStakeholders { get; set; }
 
 	[BindProperty]

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml
@@ -98,6 +98,9 @@
 						<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
 							Are there any shared facilities on site?
 						</legend>
+                        <span class="govuk-hint govuk-body govuk-!-margin-bottom-5">
+				            For example, a nursery, children’s centre, swimming pool, leisure centre, caretaker’s house, community library or SEN unit
+			            </span>
 						@foreach (var sharedFacilitiesOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>())
 						{
 							<div class="govuk-radios__item">

--- a/Dfe.Academies.External.Web/Pages/School/PupilNumbers.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/PupilNumbers.cshtml.cs
@@ -39,7 +39,7 @@ namespace Dfe.Academies.External.Web.Pages.School
         public int? ProjectedPupilNumbersYear3 { get; set; }
 
         [BindProperty]
-        [Required(ErrorMessage = "You must give what your projected pupil numbers based on")]
+        [Required(ErrorMessage = "You must tell us what your projected pupil numbers are based on")]
         public string? SchoolCapacityAssumptions { get; set; } = string.Empty;
 
 


### PR DESCRIPTION
Following bug tickets:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/105949?McasTsid=26110
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/105740?McasTsid=26110
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/106008?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
- Missing wording added to LandAndBuildings page
- Amended validation warning text on ApplicationSchoolConsultation page
- Amended validation warning text on future pupil numbers page

## Steps to reproduce issue (if relevant)
1. Browse to land & buildings page, additional text about shared facilities is missing
2. validation warning doesn't make sense on school consultation page
3. validation warning doesn't make sense on future pupil numbers page

## Steps to test this PR
1. Browse to land & buildings page, additional text about shared facilities now exists
2. validation warnings make sense on school consultation page
3. validation warnings make sense on future pupil numbers page

## Prerequisites
n/a
