### PR TITLE
Summary Page - not handling null values correctly

### DIFF
--- a/Dfe.Academies.External.Web/Extensions/BoolEnumExtension.cs
+++ b/Dfe.Academies.External.Web/Extensions/BoolEnumExtension.cs
@@ -23,7 +23,7 @@ internal static class BoolEnumExtension
 	public static string GetStringDescription(this bool? value)
 	{
 		if (!value.HasValue)
-			return QuestionAndAnswerConstants.NoAnswer;
+			return QuestionAndAnswerConstants.NoInfoAnswer;
 
 		if (value.Value)
 		{

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrantSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrantSummary.cshtml.cs
@@ -72,8 +72,8 @@ public class ApplicationPreOpeningSupportGrantSummaryModel : BasePageEditModel
 		
 		heading1.Sections.Add(new(
 			ApplicationPreOpeningSupportGrantSectionViewModel.FundsSchoolOrTrust,
-			string.IsNullOrWhiteSpace(selectedSchool.SchoolSupportGrantFundsPaidTo.ToString()) ? 
-				QuestionAndAnswerConstants.NoInfoAnswer :  selectedSchool.SchoolSupportGrantFundsPaidTo?.GetDescription()
+			(string.IsNullOrWhiteSpace(selectedSchool.SchoolSupportGrantFundsPaidTo.ToString()) ?
+				QuestionAndAnswerConstants.NoInfoAnswer : selectedSchool.SchoolSupportGrantFundsPaidTo?.GetDescription()) ?? string.Empty
 		));
 
 		var vm = new List<ApplicationPreOpeningSupportGrantHeadingViewModel> { heading1 };

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
@@ -64,16 +64,15 @@ namespace Dfe.Academies.External.Web.Pages.School
 			SchoolConsultationSummaryHeadingViewModel heading1 = new(SchoolPupilNumbersSummaryHeadingViewModel.Heading,
 				"/school/ApplicationSchoolConsultation");
 
-			// TODO MR:- for answer, consume QuestionAndAnswerConstants.NoInfoAnswer if string.IsNullOrWhiteSpace()
-			// OR data from API
-
-			heading1.Sections.Add(new(SchoolConsultationSummarySectionViewModel.HasTheGoverningBodyConsulted, "??")
+			// TODO MR:- data from API
+			heading1.Sections.Add(new(SchoolConsultationSummarySectionViewModel.HasTheGoverningBodyConsulted,
+				"??")
 			{
 				SubQuestionAndAnswers = new()
 				{
 					new SchoolConsultationSummarySectionViewModel(
 						SchoolConsultationSummarySectionViewModel.WhenDoesTheGoverningBodyPlanToConsult,
-						"TBC"
+						QuestionAndAnswerConstants.NoInfoAnswer
 					)
 				}
 			});

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
@@ -66,13 +66,13 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			// TODO MR:- data from API
 			heading1.Sections.Add(new(SchoolConsultationSummarySectionViewModel.HasTheGoverningBodyConsulted,
-				"??")
+				QuestionAndAnswerConstants.NoInfoAnswer)
 			{
 				SubQuestionAndAnswers = new()
 				{
 					new SchoolConsultationSummarySectionViewModel(
 						SchoolConsultationSummarySectionViewModel.WhenDoesTheGoverningBodyPlanToConsult,
-						QuestionAndAnswerConstants.NoInfoAnswer
+						QuestionAndAnswerConstants.NoAnswer
 					)
 				}
 			});

--- a/Dfe.Academies.External.Web/Pages/School/FinancesReview.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/FinancesReview.cshtml.cs
@@ -75,19 +75,19 @@ namespace Dfe.Academies.External.Web.Pages.School
 			// PFYEndDate
 			PFYheading.Sections.Add(new(FinancesReviewSectionViewModel.PFYEndDate,
 				previousFinancialYear.FinancialYearEndDate.HasValue ?
-					previousFinancialYear.FinancialYearEndDate.Value.ToShortDateString() : QuestionAndAnswerConstants.NoAnswer)
+					previousFinancialYear.FinancialYearEndDate.Value.ToShortDateString() : QuestionAndAnswerConstants.NoInfoAnswer)
 			);
 			//PFYRevenue
 			PFYheading.Sections.Add(new(FinancesReviewSectionViewModel.PFYRevenue,
 				previousFinancialYear.Revenue.HasValue ?
-					previousFinancialYear.Revenue.Value.ToString() : QuestionAndAnswerConstants.NoAnswer)
+					previousFinancialYear.Revenue.Value.ToString() : QuestionAndAnswerConstants.NoInfoAnswer)
 			);
 			//PFYRevenueStatus
 			//PFYRevenueStatusExplained - SubQ
 			PFYheading.Sections.Add(new(
 				FinancesReviewSectionViewModel.Status,
 				(previousFinancialYear.RevenueStatus.HasValue ?
-					previousFinancialYear.RevenueStatus.Value.GetDescription() : QuestionAndAnswerConstants.NoAnswer)
+					previousFinancialYear.RevenueStatus.Value.GetDescription() : QuestionAndAnswerConstants.NoInfoAnswer)
 			)
 			{
 				SubQuestionAndAnswers = new()
@@ -102,14 +102,14 @@ namespace Dfe.Academies.External.Web.Pages.School
 			//PFYCapitalCarryForward
 			PFYheading.Sections.Add(new(FinancesReviewSectionViewModel.PFYCapitalCarryForward,
 				previousFinancialYear.CapitalCarryForward.HasValue ?
-					previousFinancialYear.CapitalCarryForward.Value.ToString() : QuestionAndAnswerConstants.NoAnswer)
+					previousFinancialYear.CapitalCarryForward.Value.ToString() : QuestionAndAnswerConstants.NoInfoAnswer)
 			);
 			//PFYCapitalCarryForwardStatus
 			//PFYCapitalCarryForwardExplained - SubQ
 			PFYheading.Sections.Add(new(
 				FinancesReviewSectionViewModel.Status,
 				(previousFinancialYear.CapitalCarryForwardStatus.HasValue ?
-					previousFinancialYear.CapitalCarryForwardStatus.Value.GetDescription() : QuestionAndAnswerConstants.NoAnswer)
+					previousFinancialYear.CapitalCarryForwardStatus.Value.GetDescription() : QuestionAndAnswerConstants.NoInfoAnswer)
 			)
 			{
 				SubQuestionAndAnswers = new()

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using Dfe.Academies.External.Web.Enums;
+using Dfe.Academies.External.Web.Extensions;
 using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
@@ -62,37 +63,37 @@ namespace Dfe.Academies.External.Web.Pages.School
 		{
 			SchoolName = selectedSchool.SchoolName;
 
+			var landAndBuildings = selectedSchool.LandAndBuildings;
+
 			SchoolLandAndBuildingsSummaryHeadingViewModel heading1 = new(SchoolLandAndBuildingsSummaryHeadingViewModel.Heading,
 				"/school/LandAndBuildings")
 			{
-				Status = selectedSchool.LandAndBuildings.WorksPlanned.HasValue ?
+				Status = landAndBuildings.WorksPlanned.HasValue ?
 					SchoolConversionComponentStatus.Complete
 					: SchoolConversionComponentStatus.NotStarted
 			};
 
 			heading1.Sections.Add(new(SchoolLandAndBuildingsSummarySectionViewModel.LandOwnership,
-				selectedSchool.LandAndBuildings.OwnerExplained ?? QuestionAndAnswerConstants.NoAnswer)
+				landAndBuildings.OwnerExplained ?? QuestionAndAnswerConstants.NoAnswer)
 			);
 
 			heading1.Sections.Add(new(
 				SchoolLandAndBuildingsSummarySectionViewModel.PlannedBuildingWorks,
-				(selectedSchool.LandAndBuildings.WorksPlanned.HasValue ?
-					"Yes" :
-					"No")
+				(landAndBuildings.WorksPlanned.GetStringDescription())
 				)
 			{
 				SubQuestionAndAnswers = new()
 				{
 					new SchoolLandAndBuildingsSummarySectionViewModel(
 						SchoolLandAndBuildingsSummarySectionViewModel.PlannedBuildingWorksDetails,
-						(!string.IsNullOrWhiteSpace(selectedSchool.LandAndBuildings.WorksPlannedExplained) ?
-							selectedSchool.LandAndBuildings.WorksPlannedExplained :
+						(!string.IsNullOrWhiteSpace(landAndBuildings.WorksPlannedExplained) ?
+							landAndBuildings.WorksPlannedExplained :
 							QuestionAndAnswerConstants.NoAnswer)
 					),
 					new SchoolLandAndBuildingsSummarySectionViewModel(
 						SchoolLandAndBuildingsSummarySectionViewModel.PlannedBuildingWorksWhen,
-						(selectedSchool.LandAndBuildings.WorksPlannedDate.HasValue ?
-							selectedSchool.LandAndBuildings.WorksPlannedDate.Value.ToString("dd/MM/yyyy") :
+						(landAndBuildings.WorksPlannedDate.HasValue ?
+							landAndBuildings.WorksPlannedDate.Value.ToString("dd/MM/yyyy") :
 							QuestionAndAnswerConstants.NoAnswer)
 					)
 				}
@@ -100,16 +101,14 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			heading1.Sections.Add(new(
 				SchoolLandAndBuildingsSummarySectionViewModel.SharedFacilities,
-				(selectedSchool.LandAndBuildings.FacilitiesShared.HasValue ?
-					"Yes" :
-					"No")
+				(landAndBuildings.FacilitiesShared.GetStringDescription())
 			)
 			{
 				SubQuestionAndAnswers = new()
 				{
 					new SchoolLandAndBuildingsSummarySectionViewModel(
 						SchoolLandAndBuildingsSummarySectionViewModel.SharedFacilitiesList,
-						selectedSchool.LandAndBuildings.FacilitiesSharedExplained ??
+						landAndBuildings.FacilitiesSharedExplained ??
 						QuestionAndAnswerConstants.NoAnswer
 					)
 				}
@@ -117,16 +116,14 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			heading1.Sections.Add(new(
 				SchoolLandAndBuildingsSummarySectionViewModel.Grants,
-				(selectedSchool.LandAndBuildings.Grants.HasValue ?
-					"Yes" :
-					"No")
+				(landAndBuildings.Grants.GetStringDescription())
 				)
 			{
 				SubQuestionAndAnswers = new()
 				{
 					new SchoolLandAndBuildingsSummarySectionViewModel(
 						SchoolLandAndBuildingsSummarySectionViewModel.GrantBodies,
-						selectedSchool.LandAndBuildings.GrantsAwardingBodies ??
+						landAndBuildings.GrantsAwardingBodies ??
 						QuestionAndAnswerConstants.NoAnswer
 					)
 				}
@@ -134,33 +131,27 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			heading1.Sections.Add(new(
 				SchoolLandAndBuildingsSummarySectionViewModel.PFI,
-				(selectedSchool.LandAndBuildings.PartOfPFIScheme.HasValue ?
-					"Yes" :
-					"No")
+				(landAndBuildings.PartOfPFIScheme.GetStringDescription())
 				)
 			{
 				SubQuestionAndAnswers = new()
 				{
 					new SchoolLandAndBuildingsSummarySectionViewModel(
 						SchoolLandAndBuildingsSummarySectionViewModel.PFIKind,
-						selectedSchool.LandAndBuildings.PartOfPFISchemeType ??
+						landAndBuildings.PartOfPFISchemeType ??
 						QuestionAndAnswerConstants.NoAnswer)
 				}
 			});
 
 			heading1.Sections.Add(new(
 				SchoolLandAndBuildingsSummarySectionViewModel.PrioritySchoolBuildingProgram,
-				(selectedSchool.LandAndBuildings.PartOfPrioritySchoolsBuildingProgramme.HasValue ?
-					"Yes" :
-					"No")
+				(landAndBuildings.PartOfPrioritySchoolsBuildingProgramme.GetStringDescription())
 				)
 			);
 
 			heading1.Sections.Add(new(
 				SchoolLandAndBuildingsSummarySectionViewModel.BuildingSchoolsForTheFuture,
-				(selectedSchool.LandAndBuildings.PartOfBuildingSchoolsForFutureProgramme.HasValue ?
-					"Yes" :
-					"No")
+				(landAndBuildings.PartOfBuildingSchoolsForFutureProgramme.GetStringDescription())
 				)
 			);
 

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
@@ -74,7 +74,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 			};
 
 			heading1.Sections.Add(new(SchoolLandAndBuildingsSummarySectionViewModel.LandOwnership,
-				landAndBuildings.OwnerExplained ?? QuestionAndAnswerConstants.NoAnswer)
+				landAndBuildings.OwnerExplained ?? QuestionAndAnswerConstants.NoInfoAnswer)
 			);
 
 			heading1.Sections.Add(new(

--- a/Dfe.Academies.External.Web/Pages/School/PupilNumbersSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/PupilNumbersSummary.cshtml.cs
@@ -74,31 +74,31 @@ namespace Dfe.Academies.External.Web.Pages.School
 			heading1.Sections.Add(
 				new(
 					SchoolPupilNumbersSummarySectionViewModel.PupilNumberYr1,
-					selectedSchool.ProjectedPupilNumbersYear1?.ToString() ?? QuestionAndAnswerConstants.NoAnswer
+					selectedSchool.ProjectedPupilNumbersYear1?.ToString() ?? QuestionAndAnswerConstants.NoInfoAnswer
 					)
 				);
 			heading1.Sections.Add(
 				new(
 					SchoolPupilNumbersSummarySectionViewModel.PupilNumberYr2,
-					selectedSchool.ProjectedPupilNumbersYear2?.ToString() ?? QuestionAndAnswerConstants.NoAnswer
+					selectedSchool.ProjectedPupilNumbersYear2?.ToString() ?? QuestionAndAnswerConstants.NoInfoAnswer
 					)
 				);
 			heading1.Sections.Add(
 				new(
 					SchoolPupilNumbersSummarySectionViewModel.PupilNumberYr3,
-					selectedSchool.ProjectedPupilNumbersYear3?.ToString() ?? QuestionAndAnswerConstants.NoAnswer
+					selectedSchool.ProjectedPupilNumbersYear3?.ToString() ?? QuestionAndAnswerConstants.NoInfoAnswer
 					)
 				);
 			heading1.Sections.Add(
 				new(
 					SchoolPupilNumbersSummarySectionViewModel.NumbersBasedUpon,
-					selectedSchool.SchoolCapacityAssumptions ?? QuestionAndAnswerConstants.NoAnswer
+					selectedSchool.SchoolCapacityAssumptions ?? QuestionAndAnswerConstants.NoInfoAnswer
 					)
 				);
 			heading1.Sections.Add(
 				new(
 					SchoolPupilNumbersSummarySectionViewModel.PAN,
-					selectedSchool.SchoolCapacityPublishedAdmissionsNumber?.ToString() ?? QuestionAndAnswerConstants.NoAnswer
+					selectedSchool.SchoolCapacityPublishedAdmissionsNumber?.ToString() ?? QuestionAndAnswerConstants.NoInfoAnswer
 					)
 				);
 

--- a/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml.cs
@@ -70,7 +70,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 																		"/school/ApplicationSelectSchool")
 			{
 				Status = selectedSchool.URN != 0 ?
-					SchoolConversionComponentStatus.Complete
+					SchoolConversionComponentStatus.Incomplete
 					: SchoolConversionComponentStatus.NotStarted
 			};
 
@@ -82,85 +82,97 @@ namespace Dfe.Academies.External.Web.Pages.School
 				new(SchoolConversionComponentHeadingViewModel.HeadingApplicationContactDetails,
 				"/school/SchoolMainContacts")
 				{
-					Status = !String.IsNullOrEmpty(selectedSchool.SchoolConversionContactHeadName) ?
-					SchoolConversionComponentStatus.Complete
-					: SchoolConversionComponentStatus.NotStarted
+					Status = !string.IsNullOrEmpty(selectedSchool.SchoolConversionContactHeadName) ?
+					SchoolConversionComponentStatus.Complete : SchoolConversionComponentStatus.NotStarted
 				};
-
-
+			
 			heading2.Sections.Add(
 				new(
 					SchoolConversionComponentSectionViewModel.ContactDetailsHeadteacherNameSectionName,
-					selectedSchool.SchoolConversionContactHeadName ?? QuestionAndAnswerConstants.NoAnswer)
-				);
+					!string.IsNullOrWhiteSpace(selectedSchool.SchoolConversionContactHeadName) ?
+					selectedSchool.SchoolConversionContactHeadName : QuestionAndAnswerConstants.NoInfoAnswer
+					));
 			heading2.Sections.Add(
 				new(
 					SchoolConversionComponentSectionViewModel.ContactDetailsHeadteacherEmailSectionName,
-					selectedSchool.SchoolConversionContactHeadEmail ?? QuestionAndAnswerConstants.NoAnswer)
-				);
+					!string.IsNullOrWhiteSpace(selectedSchool.SchoolConversionContactHeadEmail) ?
+						selectedSchool.SchoolConversionContactHeadEmail : QuestionAndAnswerConstants.NoInfoAnswer
+						));
 			heading2.Sections.Add(
 				new(
 					SchoolConversionComponentSectionViewModel.ContactDetailsHeadteacherTelNoSectionName,
-					selectedSchool.SchoolConversionContactHeadTel ?? QuestionAndAnswerConstants.NoAnswer)
-				);
+					!string.IsNullOrWhiteSpace(selectedSchool.SchoolConversionContactHeadTel) ?
+						selectedSchool.SchoolConversionContactHeadTel : QuestionAndAnswerConstants.NoInfoAnswer
+						));
 			heading2.Sections.Add(
 				new(
 					SchoolConversionComponentSectionViewModel.ContactDetailsChairNameSectionName,
-					selectedSchool.SchoolConversionContactChairName ?? QuestionAndAnswerConstants.NoAnswer)
-				);
+					!string.IsNullOrWhiteSpace(selectedSchool.SchoolConversionContactChairName) ?
+						selectedSchool.SchoolConversionContactChairName : QuestionAndAnswerConstants.NoInfoAnswer
+						));
 			heading2.Sections.Add(
 				new(
 					SchoolConversionComponentSectionViewModel.ContactDetailsChairEmailSectionName,
-					selectedSchool.SchoolConversionContactChairEmail ?? QuestionAndAnswerConstants.NoAnswer)
-				);
+					!string.IsNullOrWhiteSpace(selectedSchool.SchoolConversionContactChairEmail) ?
+						selectedSchool.SchoolConversionContactChairEmail : QuestionAndAnswerConstants.NoInfoAnswer
+						));
 			heading2.Sections.Add(
 				new(
 					SchoolConversionComponentSectionViewModel.ContactDetailsChairTelNoSectionName,
-					selectedSchool.SchoolConversionContactChairTel ?? QuestionAndAnswerConstants.NoAnswer)
-				);
+					!string.IsNullOrWhiteSpace(selectedSchool.SchoolConversionContactChairTel) ?
+						selectedSchool.SchoolConversionContactChairTel : QuestionAndAnswerConstants.NoInfoAnswer
+						));
 			heading2.Sections.Add(
 				new(
 					SchoolConversionComponentSectionViewModel.ContactDetailsMainContactRoleSectionName,
-					!string.IsNullOrEmpty(selectedSchool.SchoolConversionContactRole) ? selectedSchool.SchoolConversionContactRole.ToEnum<MainConversionContact>().GetDescription() : QuestionAndAnswerConstants.NoAnswer)
-				);
-			if (!string.IsNullOrEmpty(selectedSchool.SchoolConversionContactRole) && selectedSchool.SchoolConversionContactRole.Equals(MainConversionContact.Other.ToString()))
+					!string.IsNullOrEmpty(selectedSchool.SchoolConversionContactRole) 
+						? selectedSchool.SchoolConversionContactRole.ToEnum<MainConversionContact>().GetDescription() 
+						: QuestionAndAnswerConstants.NoInfoAnswer
+				));
+
+			// check we have an 'Other' contact role before outputting sub q's
+			if (!string.IsNullOrEmpty(selectedSchool.SchoolConversionContactRole) 
+			    && selectedSchool.SchoolConversionContactRole.Equals(MainConversionContact.Other.ToString()))
 			{
 				heading2.Sections.Add(
-					new(
-						SchoolConversionComponentSectionViewModel.ContactDetailsMainContactOtherNameSectionName,
-						selectedSchool.SchoolConversionMainContactOtherName ?? QuestionAndAnswerConstants.NoAnswer)
-				);
+					new(SchoolConversionComponentSectionViewModel.ContactDetailsMainContactOtherNameSectionName,
+						!string.IsNullOrWhiteSpace(selectedSchool.SchoolConversionMainContactOtherName) ?
+							selectedSchool.SchoolConversionMainContactOtherName : QuestionAndAnswerConstants.NoInfoAnswer
+				));
 
 				heading2.Sections.Add(
 					new(
 						SchoolConversionComponentSectionViewModel.ContactDetailsMainContactOtherEmailSectionName,
-						selectedSchool.SchoolConversionMainContactOtherEmail ?? QuestionAndAnswerConstants.NoAnswer)
-				);
+						!string.IsNullOrWhiteSpace(selectedSchool.SchoolConversionMainContactOtherEmail) ?
+							selectedSchool.SchoolConversionMainContactOtherEmail : QuestionAndAnswerConstants.NoInfoAnswer
+						));
 
 				heading2.Sections.Add(
 					new(
 						SchoolConversionComponentSectionViewModel.ContactDetailsMainContactOtherTelephoneSectionName,
-						selectedSchool.SchoolConversionMainContactOtherTelephone ?? QuestionAndAnswerConstants.NoAnswer)
-				);
+						!string.IsNullOrWhiteSpace(selectedSchool.SchoolConversionMainContactOtherTelephone) ?
+							selectedSchool.SchoolConversionMainContactOtherTelephone : QuestionAndAnswerConstants.NoInfoAnswer
+						));
 			}
 			heading2.Sections.Add(
 				new(
 					SchoolConversionComponentSectionViewModel.ContactDetailsApproversFullNameSectionName,
-					selectedSchool.SchoolConversionApproverContactName ?? QuestionAndAnswerConstants.NoAnswer)
-				);
+					!string.IsNullOrWhiteSpace(selectedSchool.SchoolConversionApproverContactName) ?
+						selectedSchool.SchoolConversionApproverContactName : QuestionAndAnswerConstants.NoInfoAnswer
+					));
 			heading2.Sections.Add(
 				new(
 					SchoolConversionComponentSectionViewModel.ContactDetailsApproversEmailSectionName,
-					selectedSchool.SchoolConversionApproverContactEmail ?? QuestionAndAnswerConstants.NoAnswer)
-				);
+					!string.IsNullOrWhiteSpace(selectedSchool.SchoolConversionApproverContactEmail) ?
+						selectedSchool.SchoolConversionApproverContactEmail : QuestionAndAnswerConstants.NoInfoAnswer
+					));
 
 			SchoolConversionComponentHeadingViewModel heading3 =
 				new(SchoolConversionComponentHeadingViewModel.HeadingApplicationPreferredDateForConversion,
 				"/school/ApplicationConversionTargetDate")
 				{
 					Status = selectedSchool.SchoolConversionTargetDateSpecified.HasValue ?
-					SchoolConversionComponentStatus.Complete
-					: SchoolConversionComponentStatus.NotStarted
+					SchoolConversionComponentStatus.Complete : SchoolConversionComponentStatus.NotStarted
 				};
 
 			heading3.Sections.Add(
@@ -172,15 +184,15 @@ namespace Dfe.Academies.External.Web.Pages.School
 					{
 						new SchoolLandAndBuildingsSummarySectionViewModel(
 							"Preferred date",
-							(selectedSchool.SchoolConversionTargetDate.HasValue ?
+							selectedSchool.SchoolConversionTargetDate.HasValue ?
 								selectedSchool.SchoolConversionTargetDate.Value.ToString("dd/MM/yyyy")
-								: QuestionAndAnswerConstants.NoAnswer)
+								: QuestionAndAnswerConstants.NoInfoAnswer
 						),
 						new SchoolLandAndBuildingsSummarySectionViewModel(
 							"Explain why you want to convert on this date",
-							(!string.IsNullOrWhiteSpace(selectedSchool.SchoolConversionTargetDateExplained) ?
+							!string.IsNullOrWhiteSpace(selectedSchool.SchoolConversionTargetDateExplained) ?
 								selectedSchool.SchoolConversionTargetDateExplained
-								: QuestionAndAnswerConstants.NoAnswer)
+								: QuestionAndAnswerConstants.NoInfoAnswer
 						)
 					}
 				});
@@ -188,7 +200,9 @@ namespace Dfe.Academies.External.Web.Pages.School
 			// TODO MR:- ApplicationJoinTrustReasons not in API yet - 08/09/2022
 			SchoolConversionComponentHeadingViewModel heading4 = new(SchoolConversionComponentHeadingViewModel.HeadingApplicationJoinTrustReason,
 				"/school/ApplicationJoinTrustReasons");
-			heading4.Sections.Add(new(SchoolConversionComponentSectionViewModel.ReasonsForJoiningTrustSectionName, "TBC"));
+			heading4.Sections.Add(new(SchoolConversionComponentSectionViewModel.ReasonsForJoiningTrustSectionName,
+				QuestionAndAnswerConstants.NoInfoAnswer
+				));
 
 			SchoolConversionComponentHeadingViewModel heading5 = new(SchoolConversionComponentHeadingViewModel.HeadingApplicationSchoolNameChange,
 				"/school/ApplicationChangeSchoolName")
@@ -200,11 +214,10 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			heading5.Sections.Add(new(
 								SchoolConversionComponentSectionViewModel.NameOfSchoolChangingSectionName,
-								(!string.IsNullOrWhiteSpace(selectedSchool.ProposedNewSchoolName) ?
+								!string.IsNullOrWhiteSpace(selectedSchool.ProposedNewSchoolName) ?
 									selectedSchool.ProposedNewSchoolName
-									: QuestionAndAnswerConstants.NoAnswer)
-								)
-			);
+									: QuestionAndAnswerConstants.NoInfoAnswer
+								));
 
 			var vm = new List<SchoolConversionComponentHeadingViewModel> { heading1, heading2, heading3, heading4, heading5 };
 

--- a/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml.cs
@@ -186,13 +186,13 @@ namespace Dfe.Academies.External.Web.Pages.School
 							"Preferred date",
 							selectedSchool.SchoolConversionTargetDate.HasValue ?
 								selectedSchool.SchoolConversionTargetDate.Value.ToString("dd/MM/yyyy")
-								: QuestionAndAnswerConstants.NoInfoAnswer
+								: QuestionAndAnswerConstants.NoAnswer
 						),
 						new SchoolLandAndBuildingsSummarySectionViewModel(
 							"Explain why you want to convert on this date",
 							!string.IsNullOrWhiteSpace(selectedSchool.SchoolConversionTargetDateExplained) ?
 								selectedSchool.SchoolConversionTargetDateExplained
-								: QuestionAndAnswerConstants.NoInfoAnswer
+								: QuestionAndAnswerConstants.NoAnswer
 						)
 					}
 				});

--- a/Dfe.Academies.External.Web/Pages/Shared/_SchoolConversionComponentPartial.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Shared/_SchoolConversionComponentPartial.cshtml
@@ -6,7 +6,7 @@
 	</td>
 	<td class="govuk-table__cell">
 		<dl>
-			<dd class="sip-overview-table__answer">
+			<dd class="">
 				<dl class="govuk-body-s">
 					<dt class="">
 						@Model.Answer
@@ -15,17 +15,20 @@
 			</dd>
 			@if (Model.SubQuestionAndAnswers.Any())
 			{
-				<dd class="sip-overview-table__answer">
+				<dd class="">
 					@foreach (var additionalInfo in Model.SubQuestionAndAnswers.ToList())
 					{
-						<dl class="govuk-body-s">
-							<dt class="">
-								@additionalInfo.Name
-							</dt>
-							<dd data-field-name="@additionalInfo.Name">
-								@additionalInfo.Answer
-							</dd>
-						</dl>
+                        @if (additionalInfo.QuestionAnswered)
+                        {
+	                        <dl class="govuk-body-s">
+		                        <dt class="">
+			                        @additionalInfo.Name
+		                        </dt>
+		                        <dd data-field-name="@additionalInfo.Name">
+			                        @additionalInfo.Answer
+		                        </dd>
+	                        </dl>
+                        }
 					}
 				</dd>
 			}

--- a/Dfe.Academies.External.Web/ViewModels/SchoolQuestionAndAnswerViewModel.cs
+++ b/Dfe.Academies.External.Web/ViewModels/SchoolQuestionAndAnswerViewModel.cs
@@ -21,4 +21,19 @@ public abstract class SchoolQuestionAndAnswerViewModel
 	// Question can have sub-questions e.g. conditional radio
 	// i.e. 'Are there any current or planned building works?'. This has 2 sub questions:- 1) provide details, 2) When is scheduled completion date
 	public List<SchoolQuestionAndAnswerViewModel> SubQuestionAndAnswers { get; set; }
+
+	public bool QuestionAnswered
+	{
+		get
+		{
+			if (Answer == QuestionAndAnswerConstants.NoAnswer)
+			{
+				return false;
+			}
+			else
+			{
+				return true;
+			}
+		}
+	}
 }


### PR DESCRIPTION
Bug fix for this bug:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/105744?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
On the land & buildings summary page when no land & buildings data exists the page shows data i.e. PlannedBuildingWorks = No

## Steps to reproduce issue (if relevant)
1. Browse to land & buildings summary page on an application with no data
2. Browse to future pupil number summary page on an application with no data
3. Browse to pre-opening support grant summary page on an application with no data
4. Browse to school overview page / about the conversion on an application with no data

## Steps to test this PR
1. Browse to land & buildings summary page on an application with no data screen should say 'not entered' against the questions. Also, should hide any sub questions not filled in.
2. Browse to future pupil number summary page on an application with no data screen should say 'not entered' against the questions
3. Browse to pre-opening support grant summary page on an application with no data screen should say 'not entered' against the questions
4. Browse to school overview page / about the conversion on an application with no data screen should say 'not entered' against the questions. Also, should hide any sub questions not filled in.

## Prerequisites
n/a
