### PR TITLE
order enum values to fix upside/down bug

### DIFF
--- a/Dfe.Academies.External.Web/Pages/School/ApplicationChangeSchoolName.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationChangeSchoolName.cshtml
@@ -28,7 +28,7 @@
 
 		<div class="govuk-form-group">
 			<div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-				@foreach (var selectOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>())
+                @foreach (var selectOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>().OrderByDescending(x => x.ToString()))
 				{
 					<div class="govuk-radios__item">
 						<input type="radio"

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml
@@ -36,7 +36,7 @@
 				Do you want the conversion to happen on a particular date?
 			</h2>
 			<div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-				@foreach (var selectOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>())
+                @foreach (var selectOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>().OrderByDescending(x => x.ToString()))
 				{
 					<div class="govuk-radios__item">
 						<input type="radio"

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml
@@ -41,7 +41,7 @@
 
 				<div class="govuk-form-group">
 					<div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-						@foreach (var consultationStakeholdersOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>())
+						@foreach (var consultationStakeholdersOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>().OrderByDescending(x => x.ToString()))
 						{
 							<div class="govuk-radios__item">
 								<input type="radio"

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml
@@ -44,7 +44,7 @@
 						<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
 							Are there any current or planned building works?
 						</legend>
-						@foreach (var buildingWorksOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>())
+                        @foreach (var buildingWorksOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>().OrderByDescending(x => x.ToString()))
 						{
 							<div class="govuk-radios__item">
 								<input type="radio"
@@ -59,7 +59,7 @@
 									@buildingWorksOption.GetDescription()
 								</label>
 							</div>
-							@if (buildingWorksOption == SelectOption.Yes || Model.SchoolBuildLandWorksPlanned == SelectOption.Yes)
+							@if (buildingWorksOption == SelectOption.Yes)
 							{
 								<div class="@(Model.HasError ? "govuk-form-group--error" : "govuk-radios__conditional")
 			                                            @(buildingWorksOption == SelectOption.No ? "govuk-radios__conditional--hidden" : "")"
@@ -101,7 +101,7 @@
                         <span class="govuk-hint govuk-body govuk-!-margin-bottom-5">
 				            For example, a nursery, children’s centre, swimming pool, leisure centre, caretaker’s house, community library or SEN unit
 			            </span>
-						@foreach (var sharedFacilitiesOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>())
+                        @foreach (var sharedFacilitiesOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>().OrderByDescending(x => x.ToString()))
 						{
 							<div class="govuk-radios__item">
 								<input type="radio"
@@ -116,7 +116,7 @@
 									@sharedFacilitiesOption.GetDescription()
 								</label>
 							</div>
-							@if (sharedFacilitiesOption == SelectOption.Yes || Model.SchoolBuildLandSharedFacilities == SelectOption.Yes)
+							@if (sharedFacilitiesOption == SelectOption.Yes)
 							{
 								<div class="@(Model.HasError ? "govuk-form-group--error" : "govuk-radios__conditional")
 			                                            @(sharedFacilitiesOption == SelectOption.No ? "govuk-radios__conditional--hidden" : "")"
@@ -141,7 +141,7 @@
 						<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
 							Has the school had any grants from Sport England, the Big Lottery Fund, or the Football Federation?
 						</legend>
-						@foreach (var landGrantsOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>())
+                        @foreach (var landGrantsOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>().OrderByDescending(x => x.ToString()))
 						{
 							<div class="govuk-radios__item">
 								<input type="radio"
@@ -156,7 +156,7 @@
 									@landGrantsOption.GetDescription()
 								</label>
 							</div>
-							@if (landGrantsOption == SelectOption.Yes || Model.SchoolBuildLandGrants == SelectOption.Yes)
+							@if (landGrantsOption == SelectOption.Yes)
 							{
 								<div class="@(Model.HasError ? "govuk-form-group--error" : "govuk-radios__conditional")
 			                                            @(landGrantsOption == SelectOption.No ? "govuk-radios__conditional--hidden" : "")"
@@ -181,7 +181,7 @@
 						<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
 							Is the school part of a Private Finance Initiative (PFI) scheme?
 						</legend>
-						@foreach (var pfiSchemeOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>())
+                        @foreach (var pfiSchemeOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>().OrderByDescending(x => x.ToString()))
 						{
 							<div class="govuk-radios__item">
 								<input type="radio"
@@ -196,7 +196,7 @@
 									@pfiSchemeOption.GetDescription()
 								</label>
 							</div>
-							@if (pfiSchemeOption == SelectOption.Yes || Model.SchoolBuildLandPFIScheme == SelectOption.Yes)
+							@if (pfiSchemeOption == SelectOption.Yes)
 							{
 								<div class="@(Model.HasError ? "govuk-form-group--error" : "govuk-radios__conditional")
 			                                            @(pfiSchemeOption == SelectOption.No ? "govuk-radios__conditional--hidden" : "")"
@@ -220,7 +220,7 @@
 						<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
 							Is the school part of the Priority School Building Programme?
 						</legend>
-						@foreach (var priorityBuildingProgrammeOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>())
+                        @foreach (var priorityBuildingProgrammeOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>().OrderByDescending(x => x.ToString()))
 						{
 							<div class="govuk-radios__item">
 								<input type="radio"
@@ -243,7 +243,7 @@
 						<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
 							Is the school part of the Building Schools for the Future Programme?
 						</legend>
-						@foreach (var futureProgrammeOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>())
+                        @foreach (var futureProgrammeOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>().OrderByDescending(x => x.ToString()))
 						{
 							<div class="govuk-radios__item">
 								<input type="radio"


### PR DESCRIPTION
Bug ticket number:-
TBC

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
The yes / no select options on the following page are the wrong way around:-
ApplicationChangeSchoolName
ApplicationConversionTargetDate
ApplicationSchoolConsultation
LandAndBuildings

## Steps to reproduce issue (if relevant)
1. Go into ApplicationChangeSchoolName - option will be no then yes
2. Go into ApplicationConversionTargetDate - option will be no then yes
3. Go into ApplicationSchoolConsultation - option will be no then yes
4. Go into LandAndBuildings- option will be no then yes

## Steps to test this PR
1. Go into ApplicationChangeSchoolName - option will be yes then no
2. Go into ApplicationConversionTargetDate - option will be yes then no
3. Go into ApplicationSchoolConsultation - option will be yes then no
4. Go into LandAndBuildings- option will be yes then no

## Prerequisites
n/a