### PR TITLE
Bugs from dan mk1

### DIFF
--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
@@ -148,7 +148,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			if (TargetDateDifferent == SelectOption.Yes && string.IsNullOrWhiteSpace(TargetDateExplained))
 			{
-				ModelState.AddModelError("TargetDateExplainedNotEntered", "You must explain why you want to convert on this date");
+				ModelState.AddModelError("TargetDateExplainedNotEntered", "You must provide details");
 				PopulateValidationMessages();
 				// MR:- date input disappears without below !!
 				RePopDatePickerModel(day, month, year);

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
@@ -139,7 +139,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			if (TargetDateDifferent == SelectOption.Yes && targetDate == DateTime.MinValue)
 			{
-				ModelState.AddModelError("SchoolConversionTargetDateNotEntered", "You must give a valid date");
+				ModelState.AddModelError("SchoolConversionTargetDateNotEntered", "You must input a valid date");
 				PopulateValidationMessages();
 				// MR:- date input disappears without below !!
 				RePopDatePickerModel(day, month, year);

--- a/Dfe.Academies.External.Web/Pages/School/CurrentFinancialYear.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/CurrentFinancialYear.cshtml
@@ -97,7 +97,7 @@
 	                                            You must enter the reason for the revenue deficit
 	                                        </a>
 		                                    <label for="revenueType-deficit" class="govuk-label">
-			                                    Explain the reason for the deficit, how the school plane to deal with it, and the recovery plan.
+			                                    Explain the reason for the deficit, how the school plan to deal with it, and the recovery plan.
 		                                    </label>
 		                                    <span class="govuk-hint">
 			                                    Provide details of the financial forecast and/or the deficit recovery plan agreed with the local authority 
@@ -160,7 +160,7 @@
 							                You must enter the reason for the capital carry forward deficit
 						                </a>
                                         <label for="capitalCarryForwardStatus-deficit" class="govuk-label">
-							                Explain the reason for the deficit, how the school plane to deal with it, and the recovery plan.
+							                Explain the reason for the deficit, how the school plan to deal with it, and the recovery plan.
 						                </label>
 						                <span class="govuk-hint">
 							                Provide details of the financial forecast and/or the deficit recovery plan agreed with the local authority 

--- a/Dfe.Academies.External.Web/Pages/School/CurrentFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/CurrentFinancialYear.cshtml.cs
@@ -159,7 +159,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			if (CFYEndDate == DateTime.MinValue)
 			{
-				ModelState.AddModelError("CFYFinancialEndDateNotEntered", "You must give a valid date");
+				ModelState.AddModelError("CFYFinancialEndDateNotEntered", "You must input a valid date");
 				PopulateValidationMessages();
 				// MR:- date input disappears without below !!
 				RePopDatePickerModel(CFYEndDateComponentDay, CFYEndDateComponentMonth, CFYEndDateComponentYear);

--- a/Dfe.Academies.External.Web/Pages/School/CurrentFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/CurrentFinancialYear.cshtml.cs
@@ -38,7 +38,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 		public decimal? Revenue { get; set; }
 
 		[BindProperty]
-		[RequiredEnum(ErrorMessage = "You must provide details")]
+		[RequiredEnum(ErrorMessage = "You must select an option")]
 		public RevenueType CFYRevenueStatus { get; set; }
 
 		[BindProperty]
@@ -48,7 +48,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 		public decimal? CapitalCarryForward { get; set; }
 
 		[BindProperty]
-		[RequiredEnum(ErrorMessage = "You must provide details")]
+		[RequiredEnum(ErrorMessage = "You must select an option")]
 		public RevenueType CFYCapitalCarryForwardStatus { get; set; }
 
 		[BindProperty]

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml.cs
@@ -217,7 +217,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			if (SchoolBuildLandWorksPlanned == SelectOption.Yes && plannedDate == DateTime.MinValue)
 			{
-				ModelState.AddModelError("SchoolBuildLandWorksPlannedDateNotEntered", "You must give a valid date");
+				ModelState.AddModelError("SchoolBuildLandWorksPlannedDateNotEntered", "You must input a valid date");
 				PopulateValidationMessages();
 				RePopDatePickerModel(day, month, year);
 				return Page();

--- a/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml
@@ -91,7 +91,7 @@
                                                 You must enter the reason for the revenue deficit
                                             </a>
                                             <label for="revenueType-deficit" class="govuk-label">
-                                                Explain the reason for the deficit, how the school plane to deal with it, and the recovery plan.
+                                                Explain the reason for the deficit, how the school plan to deal with it, and the recovery plan.
                                             </label>
                                             <span class="govuk-hint">
                                                 Provide details of the financial forecast and/or the deficit recovery plan agreed with the local authority
@@ -152,7 +152,7 @@
                                             You must enter the reason for the capital carry forward deficit
                                         </a>
                                         <label for="capitalCarryForwardStatus-deficit" class="govuk-label">
-                                            Explain the reason for the deficit, how the school plane to deal with it, and the recovery plan.
+                                            Explain the reason for the deficit, how the school plan to deal with it, and the recovery plan.
                                         </label>
                                         <span class="govuk-hint">
                                             Provide details of the financial forecast and/or the deficit recovery plan agreed with the local authority

--- a/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml.cs
@@ -42,7 +42,7 @@ public class NextFinancialYearModel : BasePageEditModel
 	public decimal Revenue { get; set; }
 
 	[BindProperty]
-	[RequiredEnum(ErrorMessage = "You must provide details")]
+	[RequiredEnum(ErrorMessage = "You must select an option")]
 	public RevenueType NFYRevenueStatus { get; set; }
 
 	[BindProperty]
@@ -57,7 +57,7 @@ public class NextFinancialYearModel : BasePageEditModel
 	public decimal CapitalCarryForward { get; set; }
 
 	[BindProperty]
-	[RequiredEnum(ErrorMessage = "You must provide details")]
+	[RequiredEnum(ErrorMessage = "You must select an option")]
 	public RevenueType NFYCapitalCarryForwardStatus { get; set; }
 
 	[BindProperty]

--- a/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml.cs
@@ -171,7 +171,7 @@ public class NextFinancialYearModel : BasePageEditModel
 
 	    if (NFYEndDate == DateTime.MinValue)
 	    {
-		    ModelState.AddModelError("NFYFinancialEndDateNotEntered", "You must give a valid date");
+		    ModelState.AddModelError("NFYFinancialEndDateNotEntered", "You must input a valid date");
 		    PopulateValidationMessages();
 			// MR:- date input disappears without below !!
 			RePopDatePickerModel(NFYEndDateComponentDay, NFYEndDateComponentMonth, NFYEndDateComponentYear);

--- a/Dfe.Academies.External.Web/Pages/School/PreviousFinancialYear.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/PreviousFinancialYear.cshtml
@@ -87,7 +87,7 @@
 	                                            You must enter the reason for the revenue deficit
 	                                        </a>
 		                                    <label for="revenueType-deficit" class="govuk-label">
-			                                    Explain the reason for the deficit, how the school plane to deal with it, and the recovery plan.
+			                                    Explain the reason for the deficit, how the school plan to deal with it, and the recovery plan.
 		                                    </label>
 		                                    <span class="govuk-hint">
 			                                    Provide details of the financial forecast and/or the deficit recovery plan agreed with the local authority 
@@ -150,7 +150,7 @@
 							                You must enter the reason for the capital carry forward deficit
 						                </a>
                                         <label for="capitalCarryForwardStatus-deficit" class="govuk-label">
-							                Explain the reason for the deficit, how the school plane to deal with it, and the recovery plan.
+							                Explain the reason for the deficit, how the school plan to deal with it, and the recovery plan.
 						                </label>
 						                <span class="govuk-hint">
 							                Provide details of the financial forecast and/or the deficit recovery plan agreed with the local authority 

--- a/Dfe.Academies.External.Web/Pages/School/PreviousFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/PreviousFinancialYear.cshtml.cs
@@ -172,7 +172,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			if (PFYEndDate == DateTime.MinValue)
 			{
-				ModelState.AddModelError("PFYFinancialEndDateNotEntered", "You must give a valid date");
+				ModelState.AddModelError("PFYFinancialEndDateNotEntered", "You must input a valid date");
 				PopulateValidationMessages();
 				// MR:- date input disappears without below !!
 				RePopDatePickerModel(PFYEndDateComponentDay, PFYEndDateComponentMonth, PFYEndDateComponentYear);

--- a/Dfe.Academies.External.Web/Pages/School/PreviousFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/PreviousFinancialYear.cshtml.cs
@@ -43,7 +43,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 		public decimal Revenue { get; set; }
 
 		[BindProperty]
-		[RequiredEnum(ErrorMessage = "You must provide details")]
+		[RequiredEnum(ErrorMessage = "You must select an option")]
 		public RevenueType PFYRevenueStatus { get; set; }
 
 		[BindProperty]
@@ -58,7 +58,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 		public decimal CapitalCarryForward { get; set; }
 
 		[BindProperty]
-		[RequiredEnum(ErrorMessage = "You must provide details")]
+		[RequiredEnum(ErrorMessage = "You must select an option")]
 		public RevenueType PFYCapitalCarryForwardStatus { get; set; }
 
 		[BindProperty]


### PR DESCRIPTION
Bugs (no ticket exists - sorry)
1) Amend all incorrect date validation messages to be - 'You must input a valid date' on financial pages
2) Amend selected option validation message to be - "You must select an option" on financial pages as per UAC
3) Amend 'Plane' - > 'Plan ' on financial pages
4) User Story #102482 – Conversion target date page - c)	If a user inputs an incorrect date - validation message is wrong as per UAC
5) User Story #102482 – Conversion target date page - In scenario 4 both messages state “You must explain why you want to convert on this date”.  The former message at the top in the box should probably read “You must provide details” as per Acceptance Criteria 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
4 Issues as per above fixes

## Steps to reproduce issue (if relevant)
1. Go to financial pages, see typos
2. Go to financial pages, don't select surplus or deficit see wrong message
3. Go to financial pages, don't select a date, see wrong message
4. Go to Conversion target date page , don't select a date, see wrong message
5.  Go to Conversion target date page , don't input a reason, see wrong message

## Steps to test this PR
1. Go to financial pages, DONT see typos
2. Go to financial pages, don't select surplus or deficit see RIGHT message
3. Go to financial pages, don't select a date, see RIGHT message
4. Go to Conversion target date page , don't select a date, see RIGHT message
5.  Go to Conversion target date page , don't input a reason, see RIGHT message

## Prerequisites
n/a
