### PR TITLE
Bugs from dan mk2

### DIFF
--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
@@ -77,10 +77,14 @@ namespace Dfe.Academies.External.Web.Pages.School
 				landAndBuildings.OwnerExplained ?? QuestionAndAnswerConstants.NoInfoAnswer)
 			);
 
+			// MR:- coming back as min date, need to check landAndBuildings.WorksPlannedDate.Value = DateTime.MinDate() !
+			var worksPlannedDate = landAndBuildings.WorksPlannedDate;
+			bool worksPlannedDateFilledIn = landAndBuildings.WorksPlannedDate.HasValue && landAndBuildings.WorksPlannedDate.Value != DateTime.MinValue;
+
 			heading1.Sections.Add(new(
 				SchoolLandAndBuildingsSummarySectionViewModel.PlannedBuildingWorks,
 				(landAndBuildings.WorksPlanned.GetStringDescription())
-				)
+			)
 			{
 				SubQuestionAndAnswers = new()
 				{
@@ -92,7 +96,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 					),
 					new SchoolLandAndBuildingsSummarySectionViewModel(
 						SchoolLandAndBuildingsSummarySectionViewModel.PlannedBuildingWorksWhen,
-						(landAndBuildings.WorksPlannedDate.HasValue ?
+						(worksPlannedDateFilledIn ?
 							landAndBuildings.WorksPlannedDate.Value.ToString("dd/MM/yyyy") :
 							QuestionAndAnswerConstants.NoAnswer)
 					)
@@ -117,7 +121,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 			heading1.Sections.Add(new(
 				SchoolLandAndBuildingsSummarySectionViewModel.Grants,
 				(landAndBuildings.Grants.GetStringDescription())
-				)
+			)
 			{
 				SubQuestionAndAnswers = new()
 				{
@@ -132,7 +136,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 			heading1.Sections.Add(new(
 				SchoolLandAndBuildingsSummarySectionViewModel.PFI,
 				(landAndBuildings.PartOfPFIScheme.GetStringDescription())
-				)
+			)
 			{
 				SubQuestionAndAnswers = new()
 				{
@@ -144,14 +148,14 @@ namespace Dfe.Academies.External.Web.Pages.School
 			});
 
 			heading1.Sections.Add(new(
-				SchoolLandAndBuildingsSummarySectionViewModel.PrioritySchoolBuildingProgram,
-				(landAndBuildings.PartOfPrioritySchoolsBuildingProgramme.GetStringDescription())
+					SchoolLandAndBuildingsSummarySectionViewModel.PrioritySchoolBuildingProgram,
+					(landAndBuildings.PartOfPrioritySchoolsBuildingProgramme.GetStringDescription())
 				)
 			);
 
 			heading1.Sections.Add(new(
-				SchoolLandAndBuildingsSummarySectionViewModel.BuildingSchoolsForTheFuture,
-				(landAndBuildings.PartOfBuildingSchoolsForFutureProgramme.GetStringDescription())
+					SchoolLandAndBuildingsSummarySectionViewModel.BuildingSchoolsForTheFuture,
+					(landAndBuildings.PartOfBuildingSchoolsForFutureProgramme.GetStringDescription())
 				)
 			);
 

--- a/Dfe.Academies.External.Web/Pages/School/SchoolMainContacts.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolMainContacts.cshtml
@@ -77,6 +77,9 @@
 				</div>
 
 				<div class="govuk-form-group">
+					<span class="govuk-fieldset__legend govuk-fieldset__legend--s">
+						Who is the main contact for the conversion?
+					</span>
 					<div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
 						@foreach (var conversionContactType in Enum.GetValues(typeof(MainConversionContact)).OfType<MainConversionContact>())
 						{
@@ -97,22 +100,22 @@
 							{
 								<div class="@(Model.OtherContactError ? "govuk-form-group--error" : "govuk-radios__conditional")
 	                                            @(Model.ViewModel.ContactRole != MainConversionContact.Other ? "govuk-radios__conditional--hidden" : "")"
-										id="conditional-contacttype-other" aria-expanded="false">
+								     id="conditional-contacttype-other" aria-expanded="false">
 									<div class="govuk-form-group govuk-error-summary__list">
 										<label for="conditional-contacttype-other" class="govuk-label">Name</label>
-										<input type="text" asp-for="@Model.ViewModel.MainContactOtherName" id="MainContactOtherName" 
-										       class="govuk-input govuk-input--width-20" />
+										<input type="text" asp-for="@Model.ViewModel.MainContactOtherName" id="MainContactOtherName"
+										       class="govuk-input govuk-input--width-20"/>
 
 										<label for="conditional-contacttype-other" class="govuk-label">Email address</label>
 										<span class="govuk-hint">
 											We will only use this to contact you regarding your application
 										</span>
 										<input type="text" asp-for="@Model.ViewModel.MainContactOtherEmail" id="MainContactOtherEmail"
-												class="govuk-input govuk-input--width-20" />
+										       class="govuk-input govuk-input--width-20"/>
 
 										<label for="conditional-contacttype-other" class="govuk-label">Telephone number</label>
 										<input type="text" asp-for="@Model.ViewModel.MainContactOtherTelephone" id="MainContactOtherTelephone"
-												class="govuk-input govuk-input--width-20" />
+										       class="govuk-input govuk-input--width-20"/>
 									</div>
 								</div>
 							}

--- a/Dfe.Academies.External.Web/Pages/Shared/_SchoolConversionComponentPartial.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Shared/_SchoolConversionComponentPartial.cshtml
@@ -21,8 +21,8 @@
                         @if (additionalInfo.QuestionAnswered)
                         {
 	                        <dl class="govuk-body-s">
-		                        <dt class="">
-			                        @additionalInfo.Name
+                                <dt class="govuk-caption-m">
+	                                @additionalInfo.Name
 		                        </dt>
 		                        <dd data-field-name="@additionalInfo.Name">
 			                        @additionalInfo.Answer


### PR DESCRIPTION
Bugs as below from meeting on 28/09/2022 (ticket numbers below):-
1) Contact Details page - “Who is the main contact for the conversion?” text missing as seen in the design
2) Summary pages - all, but mainly land and buildings one - sub question heading text should be light grey as per as-is
3) Land and buildings summary page - WorksPlannedDate showing when it's coming back from API as 01/01/1900

107715 - v1.5: Contact Details Page: “Who is the main contact for the conversion?” Text Missing Above Radio Buttons
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/107725?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
1) Contact Details page - “Who is the main contact for the conversion?” text missing as seen in the design
2) Summary pages - all, but mainly land and buildings one - sub question heading text should be light grey as per as-is
3) Land and buildings summary page - WorksPlannedDate showing when it's coming back from API as 01/01/1900

## Steps to reproduce issue (if relevant)
1) Contact Details page - “Who is the main contact for the conversion?” text missing as seen in the design
2) Summary pages - all, but mainly land and buildings one - sub question heading text should be light grey as per as-is
3) Land and buildings summary page - WorksPlannedDate showing when it's coming back from API as 01/01/1900

## Steps to test this PR
1) Browse to Contact Details page - text missing should be there
2) Browse to land and buildings summary page with sub questions - heading text should be light grey as per as-is
3) Land and buildings summary page - WorksPlannedDate shouldn't show when it's coming back from API as 01/01/1900

## Prerequisites
n/a
