### PR TITLE
Bugs fin investigations page and conversion target date

### DIFF
--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml
@@ -87,7 +87,6 @@
 				}
 			</div>
 		</div>
-
 		<br/>
 		<input type="submit" value="Save and continue" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8"/>
 	</form>

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml
@@ -89,6 +89,6 @@
 		</div>
 
 		<br/>
-		<input type="submit" value="Save and return to overview" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8"/>
+		<input type="submit" value="Save and continue" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8"/>
 	</form>
 </div>

--- a/Dfe.Academies.External.Web/Pages/School/FinancialInvestigations.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/FinancialInvestigations.cshtml
@@ -25,22 +25,24 @@
 
 		<div class="@(!ViewData.ModelState.IsValid ? "govuk-form-group--error" : "")">
 			<fieldset class="govuk-fieldset">
+				<legend id="role-hint" class="govuk-fieldset__legend">Are there any financial investigations ongoing at the school?</legend>
+
 				<div class="@(!ViewData.ModelState.IsValid ? "govuk-visually-hidden" : "")">
 					<partial name="_ValidationSummary" model="Model.ValidationErrorMessagesViewModel"/>
 				</div>
-                
+
 				<div class="govuk-form-group">
 					<div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
 						@foreach (var selectOption in Enum.GetValues(typeof(SelectOption)).OfType<SelectOption>().OrderByDescending(x => x.ToString()))
 						{
 							<div class="govuk-radios__item">
 								<input type="radio"
-										asp-for="FinanceOngoingInvestigations"
+								       asp-for="FinanceOngoingInvestigations"
 								       value="@Convert.ToInt32(selectOption)"
 								       id="selectoption@(selectOption)"
 								       class="govuk-radios__input"
 								       data-aria-controls="selectoption-@(selectOption.ToString().ToLower())"
-										checked="@(selectOption.Equals(ViewData.Model.FinanceOngoingInvestigations))"
+								       checked="@(selectOption.Equals(ViewData.Model.FinanceOngoingInvestigations))"
 								       aria-expanded="False"/>
 								<label for="selectoption@(selectOption)" class="govuk-label govuk-radios__label">
 									@selectOption.GetDescription()
@@ -48,18 +50,18 @@
 							</div>
 							@if (selectOption == SelectOption.Yes)
 							{
-                                <div class="@(Model.FinancialInvestigationsExplainError ? "govuk-form-group--error" : "govuk-radios__conditional")
+								<div class="@(Model.FinancialInvestigationsExplainError ? "govuk-form-group--error" : "govuk-radios__conditional")
 	                                            @(selectOption == SelectOption.No ? "govuk-radios__conditional--hidden" : "")"
 								     id="selectoption-yes" aria-expanded="false">
 									<div class="govuk-form-group govuk-error-summary__list">
 										<label for="selectoption-yes" class="govuk-label">Provide a brief summary of the investigation</label>
-                                        <a href="#FinancialInvestigationsExplainNotEntered" class="@(Model.FinancialInvestigationsExplainError ? "govuk-error-message" : "govuk-visually-hidden")">
-	                                        You must provide details of the investigation
+										<a href="#FinancialInvestigationsExplainNotEntered" class="@(Model.FinancialInvestigationsExplainError ? "govuk-error-message" : "govuk-visually-hidden")">
+											You must provide details of the investigation
 										</a>
 										<textarea asp-for="FinancialInvestigationsExplain" id="FinancialInvestigationsExplain"
                                           class="govuk-textarea" cols="40" rows="5" maxlength="200">				
 										</textarea>
-                                        
+
 										<div class="govuk-form-group">
 											<fieldset class="govuk-fieldset">
 												<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">

--- a/Dfe.Academies.External.Web/Pages/School/FinancialInvestigations.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/FinancialInvestigations.cshtml.cs
@@ -144,7 +144,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 				// update temp store for next step - application overview
 				TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
 
-				return RedirectToPage("SchoolOverview", new { appId = ApplicationId, urn = Urn });
+				return RedirectToPage("FinancesReview", new { appId = ApplicationId, urn = Urn });
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
Fin investigations bugs:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/107923?McasTsid=26110
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/107925?McasTsid=26110

Conversion target date bug:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/107886?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Text wrong on financial investigations page
Navigation wrong on financial investigations page on save
Button text wrong on Conversion target date page

## Steps to reproduce issue (if relevant)
Text wrong on financial investigations page
Navigation wrong on financial investigations page on save
Button text wrong on Conversion target date page

## Steps to test this PR
Text right on financial investigations page
Navigation right on financial investigations page on save
Button text right on Conversion target date page

## Prerequisites
n/a
