### PR TITLE
bug - fix save button to nav to right page and fix exception

### DIFF
--- a/Dfe.Academies.External.Web/Pages/School/ApplicationChangeSchoolName.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationChangeSchoolName.cshtml.cs
@@ -96,7 +96,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 				// MR:- save away ApplicationJoinTrustReason
 				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, new Dictionary<string, dynamic>
 				{
-					{nameof(SchoolApplyingToConvert.ConversionChangeNamePlanned), Convert.ToBoolean(ChangeName)},
+					
+					{nameof(SchoolApplyingToConvert.ConversionChangeNamePlanned), this.ChangeName == SelectOption.Yes},
 					{nameof(SchoolApplyingToConvert.ProposedNewSchoolName), ChangeSchoolName}
 				});
 


### PR DESCRIPTION
bug ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/107147?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
When pressing save on change school name page user should be re-directed to 'About the conversion' page and save button was sometimes crashing

## Steps to reproduce issue (if relevant)
1.When pressing save on change school name page user should be re-directed to 'About the conversion' page
2. save button was sometimes crashing

## Steps to test this PR
1. When pressing save on change school name page user should be re-directed to 'About the conversion' page
2. Go in and out of change school name, change from yes / no. Testing both options to ensure save doesn't crash

## Prerequisites
n/a
