### PR TITLE
Removed the error summary list form group div that was causing incorr…

### DIFF
--- a/Dfe.Academies.External.Web/Pages/School/CurrentFinancialYear.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/CurrentFinancialYear.cshtml
@@ -91,8 +91,7 @@
                                     <div class="@(Model.CFYRevenueStatusExplainedError ? "govuk-form-group--error" : "govuk-radios__conditional")
 				                                @(revenueType == RevenueType.Surplus ? "govuk-radios__conditional--hidden" : "")"
 												id="revenueType-deficit" aria-expanded="false">
-	                                    <div class="govuk-form-group govuk-error-summary__list">
-	                                        <a href="#PFYRevenueStatusExplainedNotEntered"
+	                                    <a href="#PFYRevenueStatusExplainedNotEntered"
 												class="@(Model.CFYRevenueStatusExplainedError ? "govuk-error-message" : "govuk-visually-hidden")">
 	                                            You must enter the reason for the revenue deficit
 	                                        </a>
@@ -114,8 +113,7 @@
 									            codes.
 								            </span>
 	                                        TODO MR:- file upload control !
-										</div>
-	                                </div>
+                                    </div>
 	                            }
 	                        }
 						</div>

--- a/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml
@@ -37,7 +37,7 @@
 		        </div>
 		        
 		        <div class="govuk-form-group">
-			        <fieldset class="govuk-fieldset">
+			        <fieldset class="govuk-fieldset" aria-describedby="pfy-end-date-hint" role="group">
 				        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
 					        End of next financial year 
 				        </legend>
@@ -56,7 +56,7 @@
 			        </fieldset>
 		        </div>                
 		        <div class="govuk-form-group govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-			        <fieldset class="govuk-fieldset">
+			        <fieldset class="govuk-fieldset" role="group" aria-describedby="">
 				        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
 					        Forecasted revenue carry forward at end of the next financial year (31 March)
 				        </legend>

--- a/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml
@@ -37,7 +37,7 @@
 		        </div>
 		        
 		        <div class="govuk-form-group">
-			        <fieldset class="govuk-fieldset" aria-describedby="pfy-end-date-hint" role="group">
+			        <fieldset class="govuk-fieldset">
 				        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
 					        End of next financial year 
 				        </legend>
@@ -56,7 +56,7 @@
 			        </fieldset>
 		        </div>                
 		        <div class="govuk-form-group govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-			        <fieldset class="govuk-fieldset" role="group" aria-describedby="">
+			        <fieldset class="govuk-fieldset">
 				        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
 					        Forecasted revenue carry forward at end of the next financial year (31 March)
 				        </legend>
@@ -85,8 +85,7 @@
                                     <div class="@(Model.NFYRevenueStatusExplainedError ? "govuk-form-group--error" : "govuk-radios__conditional")
 				                                @(revenueType == RevenueType.Surplus ? "govuk-radios__conditional--hidden" : "")"
 											id="revenueType-deficit" aria-expanded="false">
-                                        <div class="govuk-form-group govuk-error-summary__list">
-                                            <a href="#NFYRevenueStatusExplainedNotEntered"
+	                                    <a href="#NFYRevenueStatusExplainedNotEntered"
 												class="@(Model.NFYRevenueStatusExplainedError ? "govuk-error-message" : "govuk-visually-hidden")">
                                                 You must enter the reason for the revenue deficit
                                             </a>
@@ -109,7 +108,6 @@
                                             </span>
                                             TODO MR:- file upload control !
                                         </div>
-                                    </div>
                                 }
                             }
                         </div>

--- a/Dfe.Academies.External.Web/Pages/School/PreviousFinancialYear.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/PreviousFinancialYear.cshtml
@@ -81,8 +81,7 @@
                                     <div class="@(Model.PFYRevenueStatusExplainedError ? "govuk-form-group--error" : "govuk-radios__conditional")
 				                                @(revenueType == RevenueType.Surplus ? "govuk-radios__conditional--hidden" : "")"
 												id="revenueType-deficit" aria-expanded="false">
-	                                    <div class="govuk-form-group govuk-error-summary__list">
-	                                        <a href="#PFYRevenueStatusExplainedNotEntered"
+	                                    <a href="#PFYRevenueStatusExplainedNotEntered"
 												class="@(Model.PFYRevenueStatusExplainedError ? "govuk-error-message" : "govuk-visually-hidden")">
 	                                            You must enter the reason for the revenue deficit
 	                                        </a>
@@ -104,8 +103,7 @@
 									            codes.
 								            </span>
 	                                        TODO MR:- file upload control !
-										</div>
-	                                </div>
+                                    </div>
 	                            }
 	                        }
 						</div>


### PR DESCRIPTION
…ect styling to be applied to the hyperlinks under the deficit radio buttons

<!--- Link to issue this PR resolves -->
Resolves [#107740](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Apply%20to%20become/Stories/?workitem=107740)

## Type of change
<!--- Tick the appropriate checkbox -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
<!--- Tell us what should happen: -->
<!--- * If a new feature then briefly explain what has been added -->
<!--- * If a bug fix briefly explain what should be happening that isn't -->
The hyperlinks on the financial pages under the deficit radio buttons are the incorrect style
<!--- * If a breaking change then briefly explain what is changing -->

## Steps to reproduce issue (if relevant)
<!--- Steps to re-create bug before testing, only applies -->
<!--- if PR resolves a bug -->
1. Go to an application
2. Select the finances section
3. Go to the previous, current, and next financial year pages

## Steps to test this PR
<!--- Suggested steps reviewers need to take to test this PR -->
1. Go to the financial year pages and see if the hyperlinks are the correct styling
2. Check if the form still submits all the data correctly

## Prerequisites
<!--- Put any SQL, scripts or software packages that are required to run -->
<!--- this branch on a local copy / in production -->
