### PR TITLE
additional JSON properties for 3 sections put into API

### DIFF
--- a/Dfe.Academies.External.Web.UnitTest/ExampleJsonResponses/getApplicationResponse.json
+++ b/Dfe.Academies.External.Web.UnitTest/ExampleJsonResponses/getApplicationResponse.json
@@ -1,22 +1,37 @@
 {
-	"applicationId": 1,
-	"applicationType": 0,
-	"applicationStatus": 0,
+	"applicationId": 25,
+	"applicationType": "joinAMat",
+	"applicationStatus": "inProgress",
 	"contributors": [
 		{
-			"contributorId": 24,
+			"contributorId": 128,
 			"firstName": "Dan",
 			"lastName": "Good",
 			"emailAddress": "Dan.GOOD@education.gov.uk",
-			"role": 0,
-			"otherRoleName": null
+			"role": "other"
+		},
+		{
+			"contributorId": 129,
+			"firstName": "Andrew",
+			"lastName": "Parsons",
+			"emailAddress": "andrew.parsons@plym.sch.uk",
+			"role": "other",
+			"otherRoleName": "HeadTeacher"
+		},
+		{
+			"contributorId": 130,
+			"firstName": "Sean",
+			"lastName": "Cormac",
+			"emailAddress": "sean.cormac@plym.sch.uk",
+			"role": "other",
+			"otherRoleName": "DeputyHead"
 		}
 	],
 	"schools": [
 		{
-			"id": 20,
-			"urn": 123332,
-			"schoolName": "Frank Wise School",
+			"id": 48,
+			"urn": 113537,
+			"schoolName": "Plymstock School",
 			"landAndBuildings": {
 				"ownerExplained": "Andrew Parsons",
 				"worksPlanned": false,
@@ -27,7 +42,6 @@
 				"grants": true,
 				"grantsAwardingBodies": "grantsAwardingBodies String",
 				"partOfPfiScheme": false,
-				"partOfPfiSchemeType": null,
 				"partOfPrioritySchoolsBuildingProgramme": true,
 				"partOfBuildingSchoolsForFutureProgramme": true
 			},
@@ -60,41 +74,51 @@
 			"previousFinancialYear": {
 				"financialYearEndDate": "2023-11-15T15:06:55.953",
 				"revenue": 50000.00,
-				"revenueStatus": 1,
+				"revenueStatus": "surplus",
 				"revenueStatusExplained": "revenueExplained String",
 				"revenueStatusFileLink": "revenueStatusFileLink",
 				"capitalCarryForward": 20000.00,
-				"capitalCarryForwardStatus": 1,
+				"capitalCarryForwardStatus": "surplus",
 				"capitalCarryForwardExplained": "capital CarryForwardExplained String",
 				"capitalCarryForwardFileLink": "capitalCarryForwardFileLink String"
 			},
 			"currentFinancialYear": {
 				"financialYearEndDate": "2023-11-15T15:06:55.953",
 				"revenue": 500000.99,
-				"revenueStatus": 1,
+				"revenueStatus": "surplus",
 				"revenueStatusExplained": "revenueStatusExplained string",
 				"revenueStatusFileLink": "revenueStatusFileLink string",
 				"capitalCarryForward": 30000.00,
-				"capitalCarryForwardStatus": 1,
+				"capitalCarryForwardStatus": "surplus",
 				"capitalCarryForwardExplained": "capitalCarryForwardExplained string",
 				"capitalCarryForwardFileLink": "capitalCarryForwardFileLink string"
 			},
 			"nextFinancialYear": {
 				"financialYearEndDate": "2023-11-15T15:06:55.953",
 				"revenue": 60000.00,
-				"revenueStatus": 2,
+				"revenueStatus": "deficit",
 				"revenueStatusExplained": "revenueStatusExplained string Next Finanical Year",
 				"revenueStatusFileLink": "revenueStatusFileLink string Next Financial Year",
 				"capitalCarryForward": 60000.00,
-				"capitalCarryForwardStatus": 2,
+				"capitalCarryForwardStatus": "deficit",
 				"capitalCarryForwardExplained": "capitalCarryForwardExplained string next Financial Year",
 				"capitalCarryForwardFileLink": "capitalCarryForwardFileLink string"
 			},
+			"loans": [
+				{
+					"loanId": 26,
+					"amount": 500000.00,
+					"purpose": "The purpose of this is to totally revitalise Plymstock School as an even better",
+					"provider": "string",
+					"interestRate": 3.25,
+					"schedule": "string"
+				}
+			],
 			"schoolContributionToTrust": "string",
 			"governingBodyConsentEvidenceDocumentLink": "string",
 			"additionalInformationAdded": false,
 			"additionalInformation": "string",
-			"equalitiesImpactAssessmentCompleted": 0,
+			"equalitiesImpactAssessmentCompleted": "consideredUnlikely",
 			"equalitiesImpactAssessmentDetails": "string",
 			"schoolConversionContactHeadName": "string",
 			"schoolConversionContactHeadEmail": "andrew.parsons1@plymstock.plym.sch.uk",
@@ -109,7 +133,7 @@
 			"schoolConversionMainContactOtherRole": "string",
 			"schoolConversionApproverContactName": "string",
 			"schoolConversionApproverContactEmail": "dangood84@me.com",
-			"schoolConversionTargetDateSpecified": false,
+			"schoolConversionTargetDateSpecified": true,
 			"schoolConversionTargetDate": "2023-11-15T15:06:55.953",
 			"schoolConversionTargetDateExplained": "string",
 			"conversionChangeNamePlanned": true,
@@ -118,9 +142,9 @@
 			"projectedPupilNumbersYear1": 1000,
 			"projectedPupilNumbersYear2": 1250,
 			"projectedPupilNumbersYear3": 1500,
-			"schoolCapacityAssumptions": "string",
-			"schoolCapacityPublishedAdmissionsNumber": 0,
-			"schoolSupportGrantFundsPaidTo": 1,
+			"schoolCapacityAssumptions": "Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons Andrew Parsons ",
+			"schoolCapacityPublishedAdmissionsNumber": 1001,
+			"schoolSupportGrantFundsPaidTo": "school",
 			"confirmPaySupportGrantToSchool": false
 		}
 	]

--- a/Dfe.Academies.External.Web.UnitTest/Services/ConversionApplicationCreationServiceTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Services/ConversionApplicationCreationServiceTests.cs
@@ -22,6 +22,9 @@ namespace Dfe.Academies.External.Web.UnitTest.Services;
 internal sealed class ConversionApplicationCreationServiceTests
 {
 	private static readonly Fixture Fixture = new();
+	// below hard coded because has to be same as Id in getApplicationResponse.json
+	private const int GetApplicationId = 25;
+	private const int GetSchoolUrn = 113537;
 
 	[Test]
 	public async Task CreateNewApplication___NoContributor___ApiReturns400___BadRequest()
@@ -80,7 +83,6 @@ internal sealed class ConversionApplicationCreationServiceTests
 	public async Task AddSchoolToApplication___ApiReturns200___Ok()
 	{
 		// arrange
-		int applicationId = 1; // hard coded because has to be same as example JSON
 		int urn = Fixture.Create<int>();
 		string schoolName = Fixture.Create<string>();
 		string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
@@ -98,7 +100,7 @@ internal sealed class ConversionApplicationCreationServiceTests
 			mockConversionApplicationRetrievalService);
 
 		// assert
-		Assert.DoesNotThrowAsync(() => conversionApplicationCreationService.AddSchoolToApplication(applicationId,
+		Assert.DoesNotThrowAsync(() => conversionApplicationCreationService.AddSchoolToApplication(GetApplicationId,
 			urn,
 			schoolName));
 	}
@@ -110,7 +112,6 @@ internal sealed class ConversionApplicationCreationServiceTests
 	public async Task AddSchoolToApplication___ApiReturns500___InternalServerError()
 	{
 		// arrange
-		int applicationId = 1; // hard coded because has to be same as example JSON
 		int urn = Fixture.Create<int>();
 		string schoolName = Fixture.Create<string>();
 
@@ -129,7 +130,7 @@ internal sealed class ConversionApplicationCreationServiceTests
 			mockConversionApplicationRetrievalService);
 
 		// assert
-		Assert.ThrowsAsync<HttpRequestException>(() => conversionApplicationCreationService.AddSchoolToApplication(applicationId,
+		Assert.ThrowsAsync<HttpRequestException>(() => conversionApplicationCreationService.AddSchoolToApplication(GetApplicationId,
 			urn,
 			schoolName));
 	}
@@ -168,12 +169,10 @@ internal sealed class ConversionApplicationCreationServiceTests
 	public async Task PutApplicationDetails__NoApplication__ThrowsArgumentException()
 	{
 		//Arrange
-		var applicationId = 1;
 		var schoolUrn = 123456;
 		
 		var fixture = Fixture.Create<SchoolApplyingToConvert>();
 		var properties = fixture.GetType().GetProperties();
-
 		var dictionary = properties.ToDictionary<PropertyInfo?, string, dynamic>(prop => prop.Name, prop => prop.GetValue(fixture));
 		
 		var mockCreationHttpClientFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, string.Empty);
@@ -185,7 +184,7 @@ internal sealed class ConversionApplicationCreationServiceTests
 			mockConversionApplicationRetrievalService.Object);
 
 		//Act
-		var result = Assert.ThrowsAsync<ArgumentException>(async () => await sut.PutSchoolApplicationDetails(applicationId, schoolUrn, dictionary));
+		var result = Assert.ThrowsAsync<ArgumentException>(async () => await sut.PutSchoolApplicationDetails(GetApplicationId, schoolUrn, dictionary));
 		
 		//Assert
 		Assert.AreEqual("Application not found", result.Message);
@@ -200,7 +199,6 @@ internal sealed class ConversionApplicationCreationServiceTests
 
 		var fixture = Fixture.Create<SchoolApplyingToConvert>();
 		var properties = fixture.GetType().GetProperties();
-
 		var dictionary = properties.ToDictionary<PropertyInfo?, string, dynamic>(prop => prop.Name, prop => prop.GetValue(fixture));
 	
 		var mockCreationHttpClientFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, string.Empty);
@@ -223,7 +221,6 @@ internal sealed class ConversionApplicationCreationServiceTests
 	public async Task PutApplicationDetails__ApiReturns200__Ok()
 	{
 		//Arrange
-		var applicationId = 1;
 		var schoolUrn = 123456;
 		
 		var fixture = Fixture.Create<SchoolApplyingToConvert>();
@@ -234,15 +231,15 @@ internal sealed class ConversionApplicationCreationServiceTests
 		var mockLoggerCreationService = new Mock<ILogger<ConversionApplicationCreationService>>();
 		var mockConversionApplicationRetrievalService = new Mock<IConversionApplicationRetrievalService>();
 
-		mockConversionApplicationRetrievalService.Setup(x => x.GetApplication(applicationId))
-			.ReturnsAsync(Fixture.Build<ConversionApplication>().With(x => x.ApplicationId, applicationId).With(x => x.Schools, new List<SchoolApplyingToConvert>{new("test", schoolUrn, "")}).Create());
+		mockConversionApplicationRetrievalService.Setup(x => x.GetApplication(GetApplicationId))
+			.ReturnsAsync(Fixture.Build<ConversionApplication>().With(x => x.ApplicationId, GetApplicationId).With(x => x.Schools, new List<SchoolApplyingToConvert>{new("test", schoolUrn, "")}).Create());
 		
 		var sut = new ConversionApplicationCreationService(mockCreationHttpClientFactory.Object,
 			mockLoggerCreationService.Object,
 			mockConversionApplicationRetrievalService.Object);
 
 		//Act
-		Assert.DoesNotThrowAsync(async () => await sut.PutSchoolApplicationDetails(applicationId, schoolUrn, dictionary));
+		Assert.DoesNotThrowAsync(async () => await sut.PutSchoolApplicationDetails(GetApplicationId, schoolUrn, dictionary));
 	}
 
 	/// <summary>
@@ -252,11 +249,8 @@ internal sealed class ConversionApplicationCreationServiceTests
 	public async Task ApplicationSchoolNextFinancialYear___ApiReturns200___Ok()
 	{
 		// arrange
-		int applicationId = 1;
-		int schoolUrn = 123332;
 		var fixture = Fixture.Create<SchoolApplyingToConvert>();
 		var properties = fixture.GetType().GetProperties();
-
 		var dictionary = properties.ToDictionary<PropertyInfo?, string, dynamic>(prop => prop.Name, prop => prop.GetValue(fixture));
 
 		string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
@@ -275,8 +269,8 @@ internal sealed class ConversionApplicationCreationServiceTests
 
 		// assert
 		Assert.DoesNotThrowAsync(() => conversionApplicationCreationService.PutSchoolApplicationDetails(
-			applicationId,
-			schoolUrn,
+			GetApplicationId,
+			GetSchoolUrn,
 			dictionary
 		));
 	}
@@ -285,11 +279,8 @@ internal sealed class ConversionApplicationCreationServiceTests
 	public async Task ApplicationSchoolNextFinancialYear__ApiReturns500___InternalServerError()
 	{
 		// arrange
-		int applicationId = 1;
-		int schoolUrn = 123332;
 		var fixture = Fixture.Create<SchoolApplyingToConvert>();
 		var properties = fixture.GetType().GetProperties();
-
 		var dictionary = properties.ToDictionary<PropertyInfo?, string, dynamic>(prop => prop.Name, prop => prop.GetValue(fixture));
 
 		string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
@@ -308,8 +299,8 @@ internal sealed class ConversionApplicationCreationServiceTests
 
 		// assert
 		Assert.ThrowsAsync<HttpRequestException>(() => conversionApplicationCreationService.PutSchoolApplicationDetails(
-			applicationId,
-			schoolUrn,
+			GetApplicationId,
+			GetSchoolUrn,
 			dictionary
 		));
 	}
@@ -320,12 +311,8 @@ internal sealed class ConversionApplicationCreationServiceTests
 	public async Task ApplicationSchoolPreviousFinancialYear___ApiReturns200___Ok()
 	{
 		// arrange
-		int applicationId = 1;
-		int schoolUrn = 123332;
-
 		var fixture = Fixture.Create<SchoolApplyingToConvert>();
 		var properties = fixture.GetType().GetProperties();
-
 		var dictionary = properties.ToDictionary<PropertyInfo?, string, dynamic>(prop => prop.Name, prop => prop.GetValue(fixture));
 
 		string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
@@ -344,8 +331,8 @@ internal sealed class ConversionApplicationCreationServiceTests
 
 		// assert
 		Assert.DoesNotThrowAsync(() => conversionApplicationCreationService.PutSchoolApplicationDetails(
-			applicationId,
-			schoolUrn,
+			GetApplicationId,
+			GetSchoolUrn,
 			dictionary
 		));
 	}
@@ -354,15 +341,10 @@ internal sealed class ConversionApplicationCreationServiceTests
 	public async Task ApplicationSchoolPreviousFinancialYear__ApiReturns500___InternalServerError()
 	{
 		// arrange
-		int applicationId = 1;
-		int schoolUrn = 123332;
-		
 		var fixture = Fixture.Create<SchoolApplyingToConvert>();
 		var properties = fixture.GetType().GetProperties();
-
 		var dictionary = properties.ToDictionary<PropertyInfo?, string, dynamic>(prop => prop.Name, prop => prop.GetValue(fixture));
-
-
+		
 		string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
 		string expectedJson = await File.ReadAllTextAsync(fullFilePath);
 
@@ -379,8 +361,8 @@ internal sealed class ConversionApplicationCreationServiceTests
 
 		// assert
 		Assert.ThrowsAsync<HttpRequestException>(() => conversionApplicationCreationService.PutSchoolApplicationDetails(
-			applicationId,
-			schoolUrn,
+			GetApplicationId,
+			GetSchoolUrn,
 			dictionary
 		));
 	}

--- a/Dfe.Academies.External.Web.UnitTest/Services/ConversionApplicationRetrievalServiceTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Services/ConversionApplicationRetrievalServiceTests.cs
@@ -180,7 +180,7 @@ internal sealed class ConversionApplicationRetrievalServiceTests
 	public async Task GetConversionApplicationAuditEntries___ApiReturns200___Success()
 	{
 		// arrange
-		var expectedJson = @"{ ""foo"": ""bar"" }"; // TODO MR:- will be json from Academies API
+		var expectedJson = @"{ ""foo"": ""bar"" }"; // TODO:- will be json from Academies API
 		int expectedCount = 3; // TODO: 
 		int applicationId = 99; // TODO: 
 		var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
@@ -200,7 +200,7 @@ internal sealed class ConversionApplicationRetrievalServiceTests
 	public async Task GetSchoolApplicationComponents___ApiReturns200___Success()
 	{
 		// arrange
-		var expectedJson = @"{ ""foo"": ""bar"" }"; // TODO MR:- will be json from Academies API
+		var expectedJson = @"{ ""foo"": ""bar"" }"; // TODO:- will be json from Academies API
 		int expectedCount = 8; // TODO: 
 		int applicationId = 99; // TODO: 
 		int URN = 96; // TODO: 
@@ -221,7 +221,7 @@ internal sealed class ConversionApplicationRetrievalServiceTests
 	public async Task GetConversionApplicationContributors___ApiReturns200___Success()
 	{
 		// arrange
-		var expectedJson = @"{ ""foo"": ""bar"" }"; // TODO MR:- will be json from Academies API
+		var expectedJson = @"{ ""foo"": ""bar"" }"; // TODO:- will be json from Academies API
 		int expectedCount = 2; // TODO: 
 		int applicationId = 1; // TODO: 
 		var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);

--- a/Dfe.Academies.External.Web.UnitTest/Services/ConversionApplicationRetrievalServiceTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Services/ConversionApplicationRetrievalServiceTests.cs
@@ -18,6 +18,10 @@ namespace Dfe.Academies.External.Web.UnitTest.Services;
 [Parallelizable(ParallelScope.All)]
 internal sealed class ConversionApplicationRetrievalServiceTests
 {
+	// below hard coded because has to be same as Id in getApplicationResponse.json
+	private const int GetApplicationId = 25;
+	private const int GetSchoolUrn = 113537;
+
 	[Test]
 	public async Task GetPendingApplications___ApiReturns200___Success()
 	{
@@ -268,9 +272,7 @@ internal sealed class ConversionApplicationRetrievalServiceTests
 		// arrange
 		string fullFilePath = @$"{AppDomain.CurrentDomain.BaseDirectory}ExampleJsonResponses/getApplicationResponse.json";
 		string expectedJson = await File.ReadAllTextAsync(fullFilePath);
-		int applicationId = 1;
 		int expectedCount = 1;
-		int expectedURN = 123332;
 		ApplicationStatus status = ApplicationStatus.InProgress;
 
 		var mockFactory = SetupMockHttpClientFactory(HttpStatusCode.OK, expectedJson);
@@ -279,17 +281,17 @@ internal sealed class ConversionApplicationRetrievalServiceTests
 
 		// act
 		var applicationRetrievalService = new ConversionApplicationRetrievalService(mockFactory.Object, mockLogger.Object);
-		var application = await applicationRetrievalService.GetApplication(applicationId);
+		var application = await applicationRetrievalService.GetApplication(GetApplicationId);
 
 		// assert
 		Assert.That(application, Is.Not.Null);
-		Assert.That(application.ApplicationId, Is.EqualTo(applicationId));
-		Assert.That(application.ApplicationTitle, Is.EqualTo("Join a multi-academy trust A2B_1"));
+		Assert.That(application.ApplicationId, Is.EqualTo(GetApplicationId));
+		Assert.That(application.ApplicationTitle, Is.EqualTo("Join a multi-academy trust A2B_25"));
 		Assert.That(application.ApplicationStatus, Is.EqualTo(status));
 
 		Assert.AreEqual(expectedCount, application.Schools.Count, "Count is not correct");
-		Assert.That(application.Schools.FirstOrDefault()?.SchoolName, Is.EqualTo("Frank Wise School"));
-		Assert.That(application.Schools.FirstOrDefault()?.URN, Is.EqualTo(expectedURN));
+		Assert.That(application.Schools.FirstOrDefault()?.SchoolName, Is.EqualTo("Plymstock School"));
+		Assert.That(application.Schools.FirstOrDefault()?.URN, Is.EqualTo(GetSchoolUrn));
 	}
 
 	private static Mock<IHttpClientFactory> SetupMockHttpClientFactory(HttpStatusCode expectedStatusCode, string expectedJson)

--- a/Dfe.Academies.External.Web/Models/SchoolApplyingToConvert.cs
+++ b/Dfe.Academies.External.Web/Models/SchoolApplyingToConvert.cs
@@ -87,7 +87,7 @@ public class SchoolApplyingToConvert
 	
 		public List<SchoolLoan> Loans { get; set; } = new();
 
-		// TODO:- API
+		// TODO API:-
         public List<SchoolLease> Leases { get; set; } = new();
 
         /// <summary>

--- a/Dfe.Academies.External.Web/Models/SchoolApplyingToConvert.cs
+++ b/Dfe.Academies.External.Web/Models/SchoolApplyingToConvert.cs
@@ -21,13 +21,13 @@ public class SchoolApplyingToConvert
         public string UKPRN { get; set; }
         public SchoolLandAndBuildings LandAndBuildings { get; set; }
         public SchoolPerformance Performance { get; set; } = new();
-	public LocalAuthority LocalAuthority { get; set; } = new();
-	public PartnershipsAndAffliations PartnershipsAndAffliations { get; set; } = new();
-	public SchoolReligiousEducation ReligiousEducation { get; set; }
-	public SchoolFinancialYear PreviousFinancialYear { get; set; } = new();
-	public SchoolFinancialYear CurrentFinancialYear { get; set; } = new();
-	public SchoolFinancialYear NextFinancialYear { get; set; } = new();
-	public string SchoolContributionToTrust { get; set; }
+		public LocalAuthority LocalAuthority { get; set; } = new();
+		public PartnershipsAndAffliations PartnershipsAndAffliations { get; set; } = new();
+		public SchoolReligiousEducation ReligiousEducation { get; set; }
+		public SchoolFinancialYear PreviousFinancialYear { get; set; } = new();
+		public SchoolFinancialYear CurrentFinancialYear { get; set; } = new();
+		public SchoolFinancialYear NextFinancialYear { get; set; } = new();
+		public string SchoolContributionToTrust { get; set; }
         public string GoverningBodyConsentEvidenceDocumentLink { get; set; }
         public bool? AdditionalInformationAdded { get; set; }
         public string AdditionalInformation { get; set; }
@@ -71,14 +71,27 @@ public class SchoolApplyingToConvert
 		public PayFundsTo? SchoolSupportGrantFundsPaidTo { get; set; }
 		public bool? ConfirmPaySupportGrantToSchool { get; set; }
 
-		/// <summary>
-		/// TODO MR:- is below more a VM thing?
-		/// </summary>
-		public List<ConversionApplicationComponent> SchoolApplicationComponents { get; set; } = new();
+		// Finances Investigations
+		public bool? FinanceOngoingInvestigations { get; set; }
+		public string? FinancialInvestigationsExplain { get; set; }
+		public bool? FinancialInvestigationsTrustAware { get; set; }
 
-		//// MR:- below props from A2C-SIP - ApplyingSchool object
+		// consultation details
+		public bool? SchoolHasConsultedStakeholders { get; set; }
+		public string? SchoolPlanToConsultStakeholders { get; set; }
 
+		// declaration
+		public bool? DeclarationBodyAgree { get; set; }
+		public bool? DeclarationIAmTheChairOrHeadteacher { get; set; }
+		public string? DeclarationSignedByName { get; set; }
+	
 		public List<SchoolLoan> Loans { get; set; } = new();
 
+		// TODO:- API
         public List<SchoolLease> Leases { get; set; } = new();
+
+        /// <summary>
+        /// TODO MR:- is below more a VM thing?
+        /// </summary>
+        public List<ConversionApplicationComponent> SchoolApplicationComponents { get; set; } = new();
 }

--- a/Dfe.Academies.External.Web/Models/SchoolApplyingToConvert.cs
+++ b/Dfe.Academies.External.Web/Models/SchoolApplyingToConvert.cs
@@ -91,7 +91,7 @@ public class SchoolApplyingToConvert
         public List<SchoolLease> Leases { get; set; } = new();
 
         /// <summary>
-        /// TODO MR:- is below more a VM thing?
+        /// TODO:- is below more a VM thing?
         /// </summary>
         public List<ConversionApplicationComponent> SchoolApplicationComponents { get; set; } = new();
 }

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
@@ -166,6 +166,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 					{ nameof(SchoolApplyingToConvert.SchoolConversionTargetDate), targetDate },
 					{ nameof(SchoolApplyingToConvert.SchoolConversionTargetDateExplained), TargetDateExplained }
 				};
+
 				// MR:- call API endpoint to log data
 				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);
 

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationJoinTrustReasons.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationJoinTrustReasons.cshtml.cs
@@ -73,6 +73,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 				{
 					{ nameof(SchoolApplyingToConvert.ApplicationJoinTrustReason), ApplicationJoinTrustReason }
 				};
+
+				// TODO API:- 
 				// MR:- save away ApplicationJoinTrustReason
 				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);
 
@@ -95,7 +97,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 		{
-			// TODO MR:- populate other props from API - not implemented 18/08/2022
+			// TODO API:- populate other props from API - not implemented 18/08/2022
 			//ApplicationJoinTrustReason = ;
 		}
 	}

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationJoinTrustReasons.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationJoinTrustReasons.cshtml.cs
@@ -74,7 +74,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 					{ nameof(SchoolApplyingToConvert.ApplicationJoinTrustReason), ApplicationJoinTrustReason }
 				};
 
-				// TODO API:- 
 				// MR:- save away ApplicationJoinTrustReason
 				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);
 
@@ -97,8 +96,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 		{
-			// TODO API:- populate other props from API - not implemented 18/08/2022
-			//ApplicationJoinTrustReason = ;
+			ApplicationJoinTrustReason = selectedSchool.ApplicationJoinTrustReason;
 		}
 	}
 }

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrant.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrant.cshtml.cs
@@ -160,10 +160,6 @@ public class ApplicationPreOpeningSupportGrantModel : BasePageEditModel
 			SchoolSupportGrantFundsPaidTo = selectedSchool.SchoolSupportGrantFundsPaidTo;
 			ConfirmSchoolPay = selectedSchool.ConfirmPaySupportGrantToSchool ?? false;
 		}
-
-		// TODO MR:- populate other props from API - not implemented 22/08/2022
-		//SchoolSupportGrantFundsPaidTo = selectedSchool.PayFundsTo;
-		//ConfirmSchoolPay = selectedSchool.PayFundsTo;
 	}
 }
 

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml
@@ -47,9 +47,10 @@
 								<input type="radio"
 		                           asp-for="SchoolConsultationStakeholders"
 								       value="@Convert.ToInt32(consultationStakeholdersOption)"
-								       id="selectoption@(consultationStakeholdersOption)"
+										id="consultationStakeholdersOption@(consultationStakeholdersOption)"
 								       class="govuk-radios__input"
 										data-aria-controls="consultationStakeholdersOption-@(consultationStakeholdersOption.ToString().ToLower())"
+										checked="@(consultationStakeholdersOption.Equals(ViewData.Model.SchoolConsultationStakeholders))"
 								       aria-expanded="False"/>
 		                        <label for="consultationStakeholdersOption@(consultationStakeholdersOption)" class="govuk-label govuk-radios__label">
 									@consultationStakeholdersOption.GetDescription()
@@ -57,8 +58,7 @@
 							</div>
 		                    @if (consultationStakeholdersOption == SelectOption.No)
 							{
-                                <div class="@(Model.SchoolConsultationStakeholdersConsultError ? "govuk-form-group--error" : "govuk-radios__conditional")
-		                                          @(consultationStakeholdersOption == SelectOption.No ? "govuk-radios__conditional--hidden" : "")"
+                                <div class="@(Model.SchoolConsultationStakeholdersConsultError ? "govuk-form-group--error" : "govuk-radios__conditional"))"
 									id="consultationStakeholdersOption-no" aria-expanded="false">
 									<div class="govuk-form-group govuk-error-summary__list">
 		                                <label for="consultationStakeholdersOption-no" class="govuk-label">When does the governing body plan to consult?</label>

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
@@ -104,8 +104,8 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 			//// grab draft application from temp= null
 			var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
-			// TODO MR:- save away data
-			// await _academisationCreationService.ApplicationChangeSchoolNameAndReason(draftConversionApplication, SchoolConsultationStakeholders, SchoolConsultationStakeholdersConsult, Urn);
+			// TODO API:- save away data
+			// await _academisationCreationService.PutSchoolApplicationDetails( ApplicationId, this.Urn, dictionaryMapper);
 
 			// update temp store for next step - application overview as last step in process
 			TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
@@ -127,7 +127,7 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 	private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 	{
 		SchoolName = selectedSchool.SchoolName;
-		// TODO MR:- populate other props from API - not implemented 22/08/2022
+		// TODO API:- populate other props from API - not implemented 22/08/2022
 		//SchoolConsultationStakeholders = selectedSchool.;
 		//SchoolConsultationStakeholdersConsult = selectedSchool.;
 	}

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
@@ -104,8 +104,13 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 			//// grab draft application from temp= null
 			var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
-			// TODO API:- save away data
-			// await _academisationCreationService.PutSchoolApplicationDetails( ApplicationId, this.Urn, dictionaryMapper);
+			var dictionaryMapper = new Dictionary<string, dynamic>
+			{
+				{ nameof(SchoolApplyingToConvert.SchoolHasConsultedStakeholders), SchoolConsultationStakeholders },
+				{ nameof(SchoolApplyingToConvert.SchoolPlanToConsultStakeholders), SchoolConsultationStakeholdersConsult }
+			};
+
+			await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);
 
 			// update temp store for next step - application overview as last step in process
 			TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
@@ -127,8 +132,7 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 	private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 	{
 		SchoolName = selectedSchool.SchoolName;
-		// TODO API:- populate other props from API - not implemented 22/08/2022
-		//SchoolConsultationStakeholders = selectedSchool.;
-		//SchoolConsultationStakeholdersConsult = selectedSchool.;
+		SchoolConsultationStakeholders = selectedSchool.SchoolHasConsultedStakeholders = SelectOption.Yes;
+		SchoolConsultationStakeholdersConsult = selectedSchool.SchoolPlanToConsultStakeholders;
 	}
 }

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
@@ -132,7 +132,7 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 	private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 	{
 		SchoolName = selectedSchool.SchoolName;
-		SchoolConsultationStakeholders = selectedSchool.SchoolHasConsultedStakeholders = SelectOption.Yes;
+		SchoolConsultationStakeholders = selectedSchool.SchoolHasConsultedStakeholders != null && selectedSchool.SchoolHasConsultedStakeholders.Value ? SelectOption.Yes : SelectOption.No;
 		SchoolConsultationStakeholdersConsult = selectedSchool.SchoolPlanToConsultStakeholders;
 	}
 }

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
@@ -106,7 +106,7 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 
 			var dictionaryMapper = new Dictionary<string, dynamic>
 			{
-				{ nameof(SchoolApplyingToConvert.SchoolHasConsultedStakeholders), SchoolConsultationStakeholders },
+				{ nameof(SchoolApplyingToConvert.SchoolHasConsultedStakeholders), SchoolConsultationStakeholders == SelectOption.Yes },
 				{ nameof(SchoolApplyingToConvert.SchoolPlanToConsultStakeholders), SchoolConsultationStakeholdersConsult }
 			};
 

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
@@ -71,17 +71,19 @@ namespace Dfe.Academies.External.Web.Pages.School
 					: SchoolConversionComponentStatus.NotStarted
 			};
 
+
 			heading1.Sections.Add(new(SchoolConsultationSummarySectionViewModel.HasTheGoverningBodyConsulted,
 				selectedSchool.SchoolHasConsultedStakeholders.GetStringDescription())
 			{
-				SubQuestionAndAnswers = new()
-				{
-					new SchoolConsultationSummarySectionViewModel(
-						SchoolConsultationSummarySectionViewModel.WhenDoesTheGoverningBodyPlanToConsult,
-						selectedSchool.SchoolPlanToConsultStakeholders ??
-						QuestionAndAnswerConstants.NoAnswer
-					)
-				}
+				// MR:- no sub question showing on screen shot from Abi
+				//SubQuestionAndAnswers = new()
+				//{
+				//	new SchoolConsultationSummarySectionViewModel(
+				//		SchoolConsultationSummarySectionViewModel.WhenDoesTheGoverningBodyPlanToConsult,
+				//		selectedSchool.SchoolPlanToConsultStakeholders ??
+				//		QuestionAndAnswerConstants.NoAnswer
+				//	)
+				//}
 			});
 
 			var vm = new List<SchoolConsultationSummaryHeadingViewModel> { heading1 };

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
@@ -64,7 +64,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 			SchoolConsultationSummaryHeadingViewModel heading1 = new(SchoolPupilNumbersSummaryHeadingViewModel.Heading,
 				"/school/ApplicationSchoolConsultation");
 
-			// TODO MR:- data from API
+			// TODO API:- 
 			heading1.Sections.Add(new(SchoolConsultationSummarySectionViewModel.HasTheGoverningBodyConsulted,
 				QuestionAndAnswerConstants.NoInfoAnswer)
 			{

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
@@ -1,4 +1,6 @@
-﻿using Dfe.Academies.External.Web.Models;
+﻿using Dfe.Academies.External.Web.Enums;
+using Dfe.Academies.External.Web.Extensions;
+using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
 using Dfe.Academies.External.Web.ViewModels;
@@ -62,16 +64,21 @@ namespace Dfe.Academies.External.Web.Pages.School
 			SchoolName = selectedSchool.SchoolName;
 
 			SchoolConsultationSummaryHeadingViewModel heading1 = new(SchoolPupilNumbersSummaryHeadingViewModel.Heading,
-				"/school/ApplicationSchoolConsultation");
+				"/school/ApplicationSchoolConsultation")
+			{
+				Status = selectedSchool.SchoolHasConsultedStakeholders.HasValue ?
+					SchoolConversionComponentStatus.Complete
+					: SchoolConversionComponentStatus.NotStarted
+			};
 
-			// TODO API:- 
 			heading1.Sections.Add(new(SchoolConsultationSummarySectionViewModel.HasTheGoverningBodyConsulted,
-				QuestionAndAnswerConstants.NoInfoAnswer)
+				selectedSchool.SchoolHasConsultedStakeholders.GetStringDescription())
 			{
 				SubQuestionAndAnswers = new()
 				{
 					new SchoolConsultationSummarySectionViewModel(
 						SchoolConsultationSummarySectionViewModel.WhenDoesTheGoverningBodyPlanToConsult,
+						selectedSchool.SchoolPlanToConsultStakeholders ??
 						QuestionAndAnswerConstants.NoAnswer
 					)
 				}

--- a/Dfe.Academies.External.Web/Pages/School/CurrentFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/CurrentFinancialYear.cshtml.cs
@@ -1,10 +1,12 @@
-﻿using Dfe.Academies.External.Web.Attributes;
+﻿using System.ComponentModel.DataAnnotations;
+using Dfe.Academies.External.Web.Attributes;
 using Dfe.Academies.External.Web.Enums;
 using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using static GovUk.Frontend.AspNetCore.ComponentDefaults;
 
 namespace Dfe.Academies.External.Web.Pages.School
 {
@@ -35,6 +37,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 		public string? CFYEndDateDateYear { get; set; }
 
 		[BindProperty]
+		[Range(0, 200000000000000, ErrorMessage = "Revenue amount must be greater than 0")]
+		[Required(ErrorMessage = "You must provide a revenue amount")]
 		public decimal? Revenue { get; set; }
 
 		[BindProperty]
@@ -45,6 +49,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 		public string? CFYRevenueStatusExplained { get; set; }
 		
 		[BindProperty]
+		[Range(0, 200000000000000, ErrorMessage = "Capital carry forward amount must be greater than 0")]
+		[Required(ErrorMessage = "You must provide a capital carry forward amount")]
 		public decimal? CapitalCarryForward { get; set; }
 
 		[BindProperty]

--- a/Dfe.Academies.External.Web/Pages/School/Declaration.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/Declaration.cshtml.cs
@@ -77,13 +77,14 @@ namespace Dfe.Academies.External.Web.Pages.School
 					TempDataHelper.GetSerialisedValue<ConversionApplication>(
 						TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
-				// TODO MR:- api doesn't exist 29/09/2022
-
+				// TODO API:- 
 				//var dictionaryMapper = new Dictionary<string, dynamic>
 				//{
 				//	{ nameof(SchoolApplyingToConvert.SchoolDeclarationTeacherChair), SchoolDeclarationTeacherChair },
 				//	{ nameof(SchoolApplyingToConvert.SchoolDeclarationBodyAgree), SchoolDeclarationBodyAgree }
 				//};
+
+				//await _academisationCreationService.PutSchoolApplicationDetails( ApplicationId, this.Urn, dictionaryMapper);
 
 				// update temp store for next step - application overview
 				TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
@@ -106,7 +107,9 @@ namespace Dfe.Academies.External.Web.Pages.School
 		{
 			SchoolName = selectedSchool.SchoolName;
 
-			// TODO MR:- declaration props - only 2
+			// TODO API:- 
+			//SchoolDeclarationTeacherChair = selectedSchool.;
+			//SchoolDeclarationBodyAgree = selectedSchool.;
 		}
 	}
 }

--- a/Dfe.Academies.External.Web/Pages/School/Declaration.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/Declaration.cshtml.cs
@@ -1,5 +1,4 @@
-﻿using Dfe.Academies.External.Web.Enums;
-using Dfe.Academies.External.Web.Models;
+﻿using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -68,8 +67,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 				return Page();
 			}
 
-			// TODO :- optional validation
-
 			try
 			{
 				//// grab draft application from temp= null
@@ -77,14 +74,13 @@ namespace Dfe.Academies.External.Web.Pages.School
 					TempDataHelper.GetSerialisedValue<ConversionApplication>(
 						TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
-				// TODO API:- 
-				//var dictionaryMapper = new Dictionary<string, dynamic>
-				//{
-				//	{ nameof(SchoolApplyingToConvert.SchoolDeclarationTeacherChair), SchoolDeclarationTeacherChair },
-				//	{ nameof(SchoolApplyingToConvert.SchoolDeclarationBodyAgree), SchoolDeclarationBodyAgree }
-				//};
+				var dictionaryMapper = new Dictionary<string, dynamic>
+				{
+					{ nameof(SchoolApplyingToConvert.DeclarationIAmTheChairOrHeadteacher), SchoolDeclarationTeacherChair },
+					{ nameof(SchoolApplyingToConvert.DeclarationBodyAgree), SchoolDeclarationBodyAgree }
+				};
 
-				//await _academisationCreationService.PutSchoolApplicationDetails( ApplicationId, this.Urn, dictionaryMapper);
+				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);
 
 				// update temp store for next step - application overview
 				TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
@@ -107,9 +103,17 @@ namespace Dfe.Academies.External.Web.Pages.School
 		{
 			SchoolName = selectedSchool.SchoolName;
 
-			// TODO API:- 
-			//SchoolDeclarationTeacherChair = selectedSchool.;
-			//SchoolDeclarationBodyAgree = selectedSchool.;
+			if (selectedSchool.DeclarationIAmTheChairOrHeadteacher != null)
+			{
+				SchoolDeclarationTeacherChair = selectedSchool.DeclarationIAmTheChairOrHeadteacher.Value;
+			}
+
+			if (selectedSchool.DeclarationBodyAgree != null)
+			{
+				SchoolDeclarationBodyAgree = selectedSchool.DeclarationBodyAgree.Value;
+			}
+
+			// TODO:- DeclarationSignedByName = ???;
 		}
 	}
 }

--- a/Dfe.Academies.External.Web/Pages/School/Declaration.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/Declaration.cshtml.cs
@@ -68,7 +68,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 				return Page();
 			}
 
-			// TODO MR:- optional validation
+			// TODO :- optional validation
 
 			try
 			{

--- a/Dfe.Academies.External.Web/Pages/School/DeclarationSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/DeclarationSummary.cshtml.cs
@@ -65,7 +65,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 			DeclarationSummaryHeadingViewModel heading1 = new(DeclarationSummaryHeadingViewModel.Heading,
 				"/school/Declaration")
 			{
-				Status = !string.IsNullOrEmpty(selectedSchool.SchoolSupportGrantFundsPaidTo.ToString()) ?
+				Status = selectedSchool.DeclarationBodyAgree.HasValue ?
 					SchoolConversionComponentStatus.Complete
 					: SchoolConversionComponentStatus.NotStarted
 			};

--- a/Dfe.Academies.External.Web/Pages/School/DeclarationSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/DeclarationSummary.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using Dfe.Academies.External.Web.Enums;
+using Dfe.Academies.External.Web.Extensions;
 using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
@@ -69,11 +70,10 @@ namespace Dfe.Academies.External.Web.Pages.School
 					: SchoolConversionComponentStatus.NotStarted
 			};
 
-			// TODO:- API not done - 27/09/2022
 			// MR:- NO sub questions shown here, just yes / no for answer!
 			heading1.Sections.Add(new(
 				DeclarationSummaryHeadingViewModel.HeadingDetails,
-				QuestionAndAnswerConstants.NoInfoAnswer 
+				selectedSchool.DeclarationIAmTheChairOrHeadteacher.GetStringDescription()
 			));
 
 			var vm = new List<DeclarationSummaryHeadingViewModel> { heading1 };

--- a/Dfe.Academies.External.Web/Pages/School/FinancesReview.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/FinancesReview.cshtml.cs
@@ -305,25 +305,29 @@ namespace Dfe.Academies.External.Web.Pages.School
 			FinancesReviewHeadingViewModel financialInvestigationsHeading = new(FinancesReviewHeadingViewModel.HeadingFinancialInvestigations,
 				"/school/FinancialInvestigations")
 			{
-				Status = SchoolConversionComponentStatus.NotStarted
+				Status = selectedSchool.FinanceOngoingInvestigations.HasValue ?
+					SchoolConversionComponentStatus.Complete
+					: SchoolConversionComponentStatus.NotStarted
 			};
-
-			// TODO API:-
 
 			financialInvestigationsHeading.Sections.Add(new(
 				FinancesReviewSectionViewModel.FinanceOngoingInvestigations,
-				(QuestionAndAnswerConstants.NoInfoAnswer)
+				selectedSchool.FinanceOngoingInvestigations.GetStringDescription()
 			)
 			{
 				SubQuestionAndAnswers = new()
 				{
 					new FinancesReviewSectionViewModel(
 						FinancesReviewSectionViewModel.FinancialInvestigationsExplain,
-						QuestionAndAnswerConstants.NoAnswer
+						(!string.IsNullOrWhiteSpace(selectedSchool.FinancialInvestigationsExplain) ?
+							selectedSchool.FinancialInvestigationsExplain :
+							QuestionAndAnswerConstants.NoAnswer)
 					),
 					new FinancesReviewSectionViewModel(
 						FinancesReviewSectionViewModel.FinancialInvestigationsTrustAware,
-						QuestionAndAnswerConstants.NoAnswer
+						selectedSchool.FinancialInvestigationsTrustAware.HasValue ?
+							selectedSchool.FinancialInvestigationsTrustAware.GetStringDescription() :
+							QuestionAndAnswerConstants.NoAnswer
 					),
 				}
 			});

--- a/Dfe.Academies.External.Web/Pages/School/FinancesReview.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/FinancesReview.cshtml.cs
@@ -295,7 +295,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 				Status = SchoolConversionComponentStatus.NotStarted
 			};
 
-			// TODO:- API not done - 27/09/2022
+			// TODO API:-
 
 			return leasesHeading;
 		}
@@ -308,7 +308,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 				Status = SchoolConversionComponentStatus.NotStarted
 			};
 
-			// TODO:- API not done - 27/09/2022
+			// TODO API:-
 
 			financialInvestigationsHeading.Sections.Add(new(
 				FinancesReviewSectionViewModel.FinanceOngoingInvestigations,

--- a/Dfe.Academies.External.Web/Pages/School/FinancialInvestigations.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/FinancialInvestigations.cshtml.cs
@@ -128,18 +128,15 @@ namespace Dfe.Academies.External.Web.Pages.School
 				//// grab draft application from temp= null
 				var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
-				// TODO MR:- no API 28/09/2022
-				//var schoolFinanceInvestigations = new FinancialInvestigations(FinanceOngoingInvestigations,
-				//	SchoolFinancialInvestigationsExplain,
-				//	SchoolFinancialInvestigationsTrustAware);
+				var propertiesToPopulate =
+					new Dictionary<string, dynamic>
+					{
+						{nameof(SchoolApplyingToConvert.FinanceOngoingInvestigations), FinanceOngoingInvestigations == SelectOption.Yes},
+						{nameof(SchoolApplyingToConvert.FinancialInvestigationsExplain), FinancialInvestigationsExplain!},
+						{nameof(SchoolApplyingToConvert.FinancialInvestigationsTrustAware), FinancialInvestigationsTrustAware == SelectOption.Yes},
+					};
 
-				//var propertiesToPopulate =
-				//	new Dictionary<string, dynamic>
-				//	{
-				//		{nameof(SchoolApplyingToConvert.FinancialInvestigations), schoolFinanceInvestigations}
-				//	};
-
-				//await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, propertiesToPopulate);
+				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, propertiesToPopulate);
 
 				// update temp store for next step - application overview
 				TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
@@ -161,9 +158,9 @@ namespace Dfe.Academies.External.Web.Pages.School
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 		{
 			SchoolName = selectedSchool.SchoolName;
-
+			FinanceOngoingInvestigations = selectedSchool.FinanceOngoingInvestigations != null && selectedSchool.FinanceOngoingInvestigations.Value ? SelectOption.Yes : SelectOption.No;
+			FinancialInvestigationsExplain = selectedSchool.FinancialInvestigationsExplain;
+			FinancialInvestigationsTrustAware = selectedSchool.FinancialInvestigationsTrustAware != null && selectedSchool.FinancialInvestigationsTrustAware.Value ? SelectOption.Yes : SelectOption.No; 
 		}
-
-		// re-pop date - any dates?
 	}
 }

--- a/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml.cs
@@ -222,7 +222,7 @@ public class NextFinancialYearModel : BasePageEditModel
 			// update temp store for next step - application overview
 			TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
 
-			return RedirectToPage("FinancesLoans", new { appId = ApplicationId, urn = Urn });
+			return RedirectToPage("Loans", new { appId = ApplicationId, urn = Urn });
 		}
 		catch (Exception ex)
 		{

--- a/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
+++ b/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
@@ -114,7 +114,7 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			// TODO MR:- add to existing / form new route to think about here !
 			// application.Trust = new trust();
 
-			// TODO: wire up Academisation API / what object does a PUT return
+			// TODO API: 
 			// MR:- no response from Academies API - Just an OK
 			// await _resilientRequestProvider.PutAsync(apiurl, application);
 		}

--- a/Dfe.Academies.External.Web/Services/ConversionApplicationRetrievalService.cs
+++ b/Dfe.Academies.External.Web/Services/ConversionApplicationRetrievalService.cs
@@ -114,7 +114,7 @@ public sealed class ConversionApplicationRetrievalService : BaseService, IConver
 	{
 		try
 		{
-			// TODO: MR:- get application from API then re-shape it !
+			// TODO API: get application from API then re-shape it !
 			// var application = await GetApplication(applicationId);
 
 			// **** Mock Demo Data - as per Figma ****

--- a/Dfe.Academies.External.Web/ViewModels/DeclarationSummaryHeadingViewModel.cs
+++ b/Dfe.Academies.External.Web/ViewModels/DeclarationSummaryHeadingViewModel.cs
@@ -3,7 +3,7 @@
 	public class DeclarationSummaryHeadingViewModel : SchoolQuestionAndAnswerSectionViewModel
 	{
 		public const string Heading = "Details";
-		public const string HeadingDetails = "Q";
+		public const string HeadingDetails = "I agree with all of these statements, and believe that the facts stated in this application are true";
 
 		public DeclarationSummaryHeadingViewModel(string title, string uRi) : base(title, uRi)
 		{


### PR DESCRIPTION
Wire up API endpoint into following pages:-
Declaration Page:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/104226?McasTsid=26110

Declaration Summary Page:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/104225?McasTsid=26110

Financial Investigations Page:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/103592?McasTsid=26110

Finance Review Page:-
TBC

Consultation Details Page:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/103421?McasTsid=26110

Consultation Summary Page:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/103420?McasTsid=26110

++ these bugs while I was here
Nav on save wrong on next financial year:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/108478?McasTsid=26110

Issue on consultation page:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/107742?McasTsid=26110

Current financial year - Missing revenue / surplus validation:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/108411?McasTsid=26110

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
When you press save on Declaration Page data is persisted
When you press save on Financial Investigations Page data is persisted
When you press save on Consultation Details Page data is persisted

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1.When you press save on Declaration Page data is persisted
2. When you press save on Financial Investigations Page data is persisted
3. When you press save on Consultation Details Page data is persisted
4. consultation page: validation works correctly now
5.  next financial year: save button navigates properly to new loans page
6. Current financial year now  has revenue / surplus validation

## Prerequisites
n/a
