### PR TITLE
Finance Review page - next financial year summary shows next financial year data

### DIFF
--- a/Dfe.Academies.External.Web/Pages/School/FinancesReview.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/FinancesReview.cshtml.cs
@@ -187,7 +187,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		private FinancesReviewHeadingViewModel PopulateNextFinancialYear(SchoolApplyingToConvert selectedSchool)
 		{
-			var nextFinancialYear = selectedSchool.CurrentFinancialYear;
+			var nextFinancialYear = selectedSchool.NextFinancialYear;
 			FinancesReviewHeadingViewModel NFYheading = new(FinancesReviewHeadingViewModel.HeadingNextFinancialYear,
 				"/school/NextFinancialYear")
 			{


### PR DESCRIPTION
Resolves:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/108900?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Finance Review page - next financial year summary shows next financial year data

## Steps to reproduce issue (if relevant)
1. Go to Finance Review page - next financial year summary shows wrong data

## Steps to test this PR
1. Finance Review page - next financial year summary shows next financial year data

## Prerequisites
n/a