### PR TITLE
hard coded currency symbol as culture still not working

### DIFF
--- a/Dfe.Academies.External.Web/Pages/School/Loans.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/Loans.cshtml
@@ -61,7 +61,7 @@
 											    <dt hidden="hidden"></dt>
 											    <dd class="govuk-summary-list__value">
 												    <p class="govuk-label">Provider: <strong>@Model.LoanViewModels[i].Provider</strong></p>
-													<p class="govuk-label">Amount: <strong>@Model.LoanViewModels[i].TotalAmount.ToString("C", CultureInfo.CurrentCulture)</strong></p>
+													<p class="govuk-label">Amount: <strong>£@Model.LoanViewModels[i].TotalAmount</strong></p>
 												    <a asp-page="/school/LoanDetails" aria-describedby="component-change" class="govuk-link" asp-route-appId="@Model.ApplicationId" asp-route-urn="@Model.Urn" asp-route-id="@Model.LoanViewModels[i].Id" asp-route-isEdit="true">
 												       Change answers
 													</a>


### PR DESCRIPTION
Resolves:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/108900?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Finance Review page - next financial year summary shows next financial year data

## Steps to reproduce issue (if relevant)
1. Go to Finance Review page - next financial year summary shows wrong data

## Steps to test this PR
1. Finance Review page - next financial year summary shows next financial year data

## Prerequisites
n/a