### PR TITLE
checkbox validation on declaration page incorrect

### DIFF
--- a/Dfe.Academies.External.Web/Pages/School/Declaration.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/Declaration.cshtml.cs
@@ -67,6 +67,14 @@ namespace Dfe.Academies.External.Web.Pages.School
 				return Page();
 			}
 
+			// according to dan both values have to be true!
+			if (!SchoolDeclarationTeacherChair || !SchoolDeclarationBodyAgree)
+			{
+				ModelState.AddModelError("Declarationconfirmation", "You must confirm the declaration");
+				PopulateValidationMessages();
+				return Page();
+			}
+
 			try
 			{
 				//// grab draft application from temp= null


### PR DESCRIPTION
See bug:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/108857?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
1. User should be forced to tick box checkboxes on declaration page. But isn't

## Steps to reproduce issue (if relevant)
1. User should be forced to tick box checkboxes on declaration page. But isn't

## Steps to test this PR
1. User should be forced to tick box checkboxes on declaration page. Now is

## Prerequisites
n/a