### PR TITLE
107918 every page with radios needs a clear if user selects yes with data

### DIFF
--- a/Dfe.Academies.External.Web.UnitTest/Dfe.Academies.External.Web.UnitTest.csproj
+++ b/Dfe.Academies.External.Web.UnitTest/Dfe.Academies.External.Web.UnitTest.csproj
@@ -39,6 +39,8 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="Bogus" Version="34.0.2" />
+    <PackageReference Include="FluentValidation" Version="11.2.2" />
     <PackageReference Include="IdGen" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
@@ -54,6 +56,7 @@
 
   <ItemGroup>
     <Folder Include="AcademiesAPIResponseModels\Trusts\" />
+    <Folder Include="Validators\" />
   </ItemGroup>
 
 </Project>

--- a/Dfe.Academies.External.Web.UnitTest/Validators/EmailValidatorTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Validators/EmailValidatorTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading.Tasks;
+using AutoFixture;
+using Bogus;
+using Dfe.Academies.External.Web.Validators;
+using NUnit.Framework;
+
+namespace Dfe.Academies.External.Web.UnitTest.Validators;
+
+[Parallelizable(ParallelScope.All)]
+internal sealed class EmailValidatorTests
+{
+	private static readonly Fixture Fixture = new();
+	private static readonly Faker Faker = new();
+	
+	[Test]
+	public async Task EmailValidator___ValidEmail___IsValidTrue()
+	{
+		// arrange
+		var emailAddress = new EmailAddress(Faker.Internet.Email());
+
+		var emailValidator = new EmailValidator();
+
+		// act
+		var validationResult = await emailValidator.ValidateAsync(emailAddress);
+
+		// assert
+		Assert.That(validationResult.IsValid, Is.True);
+	}
+
+	[Test]
+	public async Task EmailValidator___InValidEmail___IsValidFalse()
+	{
+		// arrange
+		var emailAddress = new EmailAddress(Fixture.Create<string>());
+
+		var emailValidator = new EmailValidator();
+
+		// act
+		var validationResult = await emailValidator.ValidateAsync(emailAddress);
+
+		// assert
+		Assert.That(validationResult.IsValid, Is.False);
+	}
+}

--- a/Dfe.Academies.External.Web/Dfe.Academies.External.Web.csproj
+++ b/Dfe.Academies.External.Web/Dfe.Academies.External.Web.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="11.2.2" />
     <PackageReference Include="GovUk.Frontend.AspNetCore" Version="0.5.1" />
     <PackageReference Include="jQuery.Validation" Version="1.19.5" />
     <PackageReference Include="Sentry.AspNetCore" Version="3.20.1" />

--- a/Dfe.Academies.External.Web/Pages/AddAContributor.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/AddAContributor.cshtml.cs
@@ -141,9 +141,17 @@ namespace Dfe.Academies.External.Web.Pages
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// does not apply on this page
+			return new();
 		}
 
 		private void PopulateUiModel(ConversionApplication? application)

--- a/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml.cs
@@ -168,9 +168,10 @@ namespace Dfe.Academies.External.Web.Pages
 		}
 
 		///<inheritdoc/>
-		public override void ClearOptionalData()
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
 		{
 			// does not apply on this page
+			return new();
 		}
 	}
 }

--- a/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml.cs
@@ -161,9 +161,16 @@ namespace Dfe.Academies.External.Web.Pages
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override void ClearOptionalData()
+		{
+			// does not apply on this page
 		}
 	}
 }

--- a/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
+++ b/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
@@ -140,4 +140,10 @@ public abstract class BasePageEditModel : BasePageModel
 			return DateTime.MinValue;
 		}
 	}
+
+	/// <summary>
+	/// Call this func before save / PUT to API, to clear out optional data
+	/// i.e. if user changes answer from no -> yes need to clear out optional string data capture
+	/// </summary>
+	public abstract void ClearOptionalData();
 }

--- a/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
+++ b/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
@@ -145,5 +145,5 @@ public abstract class BasePageEditModel : BasePageModel
 	/// Call this func before save / PUT to API, to clear out optional data
 	/// i.e. if user changes answer from no -> yes need to clear out optional string data capture
 	/// </summary>
-	public abstract void ClearOptionalData();
+	public abstract Dictionary<string, dynamic> PopulateUpdateDictionary();
 }

--- a/Dfe.Academies.External.Web/Pages/Base/BasePageModel.cs
+++ b/Dfe.Academies.External.Web/Pages/Base/BasePageModel.cs
@@ -22,8 +22,15 @@ public abstract class BasePageModel : PageModel
 		);
 	}
 
+	/// <summary>
+	/// setup model state errors
+	/// </summary>
 	public abstract void PopulateValidationMessages();
 
+	/// <summary>
+	/// Populate ViewData["Errors"] with model state errors to then be displayed by _ErrorMessages partial view
+	/// on post-back
+	/// </summary>
 	protected void PopulateViewDataErrorsWithModelStateErrors()
 	{
 		ViewData["Errors"] = ConvertModelStateToDictionary();

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationChangeSchoolName.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationChangeSchoolName.cshtml.cs
@@ -119,6 +119,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 		///<inheritdoc/>
 		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
 		{
+			// if school NOT changing name blank out 'ProposedNewSchoolName'
 			if (ChangeName == SelectOption.No)
 			{
 				return new Dictionary<string, dynamic>

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationChangeSchoolName.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationChangeSchoolName.cshtml.cs
@@ -93,13 +93,10 @@ namespace Dfe.Academies.External.Web.Pages.School
 				//// grab draft application from temp= null
 				var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
+				var dictionaryMapper = PopulateUpdateDictionary();
+
 				// MR:- save away ApplicationJoinTrustReason
-				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, new Dictionary<string, dynamic>
-				{
-					
-					{nameof(SchoolApplyingToConvert.ConversionChangeNamePlanned), this.ChangeName == SelectOption.Yes},
-					{nameof(SchoolApplyingToConvert.ProposedNewSchoolName), ChangeSchoolName}
-				});
+				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);
 
 				// update temp store for next step - application overview as last step in process
 				TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
@@ -113,9 +110,31 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			if (ChangeName == SelectOption.No)
+			{
+				return new Dictionary<string, dynamic>
+				{
+					{ nameof(SchoolApplyingToConvert.ConversionChangeNamePlanned), false},
+					{ nameof(SchoolApplyingToConvert.ProposedNewSchoolName), null }
+				};
+			}
+			else
+			{
+				return new Dictionary<string, dynamic>
+				{
+					{ nameof(SchoolApplyingToConvert.ConversionChangeNamePlanned), true },
+					{ nameof(SchoolApplyingToConvert.ProposedNewSchoolName), ChangeSchoolName }
+				};
+			}
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationChangeSchoolName.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationChangeSchoolName.cshtml.cs
@@ -133,7 +133,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 				return new Dictionary<string, dynamic>
 				{
 					{ nameof(SchoolApplyingToConvert.ConversionChangeNamePlanned), true },
-					{ nameof(SchoolApplyingToConvert.ProposedNewSchoolName), ChangeSchoolName }
+					{ nameof(SchoolApplyingToConvert.ProposedNewSchoolName), ChangeSchoolName! }
 				};
 			}
 		}

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationConversionTargetDate.cshtml.cs
@@ -189,6 +189,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 		///<inheritdoc/>
 		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
 		{
+			// if no specific date the school wants to convert, blank out 'SchoolConversionTargetDate' && 'SchoolConversionTargetDateExplained'
 			if (TargetDateDifferent == SelectOption.No)
 			{
 				return new Dictionary<string, dynamic>

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationJoinTrustReasons.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationJoinTrustReasons.cshtml.cs
@@ -69,10 +69,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 				//// grab draft application from temp= null
 				var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
-				var dictionaryMapper = new Dictionary<string, dynamic>
-				{
-					{ nameof(SchoolApplyingToConvert.ApplicationJoinTrustReason), ApplicationJoinTrustReason }
-				};
+				var dictionaryMapper = PopulateUpdateDictionary();
 
 				// MR:- save away ApplicationJoinTrustReason
 				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);
@@ -98,7 +95,10 @@ namespace Dfe.Academies.External.Web.Pages.School
 		///<inheritdoc/>
 		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
 		{
-			// TODO
+			return new Dictionary<string, dynamic>
+			{
+				{ nameof(SchoolApplyingToConvert.ApplicationJoinTrustReason), ApplicationJoinTrustReason }
+			};
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationJoinTrustReasons.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationJoinTrustReasons.cshtml.cs
@@ -97,7 +97,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 		{
 			return new Dictionary<string, dynamic>
 			{
-				{ nameof(SchoolApplyingToConvert.ApplicationJoinTrustReason), ApplicationJoinTrustReason }
+				{ nameof(SchoolApplyingToConvert.ApplicationJoinTrustReason), ApplicationJoinTrustReason! }
 			};
 		}
 

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationJoinTrustReasons.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationJoinTrustReasons.cshtml.cs
@@ -89,9 +89,16 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// TODO
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrant.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrant.cshtml.cs
@@ -106,25 +106,9 @@ public class ApplicationPreOpeningSupportGrantModel : BasePageEditModel
 		{
 			//// grab draft application from temp= null
 			var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
-			PayFundsTo schoolSupportGrantFundsPaidTo = PayFundsTo.School;
 
-			if (ApplicationType == ApplicationTypes.JoinAMat)
-			{
-				schoolSupportGrantFundsPaidTo = SchoolSupportGrantFundsPaidTo!.Value;
-			}
-			else
-			{
-				if (ConfirmSchoolPay != true)
-				{
-					schoolSupportGrantFundsPaidTo = PayFundsTo.Trust;
-				}
-			}
+			var dictionaryMapper = PopulateUpdateDictionary();
 
-			var dictionaryMapper = new Dictionary<string, dynamic>
-			{
-				{ nameof(SchoolApplyingToConvert.SchoolSupportGrantFundsPaidTo), schoolSupportGrantFundsPaidTo },
-				{ nameof(SchoolApplyingToConvert.ConfirmPaySupportGrantToSchool), ConfirmSchoolPay }
-			};
 			// MR:- call API endpoint to log data
 			await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);
 
@@ -149,7 +133,27 @@ public class ApplicationPreOpeningSupportGrantModel : BasePageEditModel
 	///<inheritdoc/>
 	public override Dictionary<string, dynamic> PopulateUpdateDictionary()
 	{
-		// TODO
+		PayFundsTo schoolSupportGrantFundsPaidTo = PayFundsTo.School;
+
+		if (ApplicationType == ApplicationTypes.JoinAMat)
+		{
+			schoolSupportGrantFundsPaidTo = SchoolSupportGrantFundsPaidTo!.Value;
+		}
+		else
+		{
+			if (!ConfirmSchoolPay)
+			{
+				schoolSupportGrantFundsPaidTo = PayFundsTo.Trust;
+			}
+		}
+
+		// TODO:- do we need to switch value of ConfirmSchoolPay around???????
+
+		return new Dictionary<string, dynamic>
+		{
+			{ nameof(SchoolApplyingToConvert.SchoolSupportGrantFundsPaidTo), schoolSupportGrantFundsPaidTo },
+			{ nameof(SchoolApplyingToConvert.ConfirmPaySupportGrantToSchool), ConfirmSchoolPay }
+		};
 	}
 
 	private void PopulateUiModel(SchoolApplyingToConvert selectedSchool, ConversionApplication? conversionApplication)

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrant.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrant.cshtml.cs
@@ -1,5 +1,4 @@
 ﻿using Dfe.Academies.External.Web.Enums;
-using Dfe.Academies.External.Web.Extensions;
 using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
@@ -141,9 +140,16 @@ public class ApplicationPreOpeningSupportGrantModel : BasePageEditModel
 		}
 	}
 
+	///<inheritdoc/>
 	public override void PopulateValidationMessages()
 	{
 		PopulateViewDataErrorsWithModelStateErrors();
+	}
+
+	///<inheritdoc/>
+	public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+	{
+		// TODO
 	}
 
 	private void PopulateUiModel(SchoolApplyingToConvert selectedSchool, ConversionApplication? conversionApplication)

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrantSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrantSummary.cshtml.cs
@@ -54,9 +54,17 @@ public class ApplicationPreOpeningSupportGrantSummaryModel : BasePageEditModel
 		}
 	}
 
+	///<inheritdoc/>
 	public override void PopulateValidationMessages()
 	{
 		PopulateViewDataErrorsWithModelStateErrors();
+	}
+
+	///<inheritdoc/>
+	public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+	{
+		// does not apply on this page
+		return new();
 	}
 
 	private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
@@ -104,11 +104,13 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 			//// grab draft application from temp= null
 			var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
-			var dictionaryMapper = new Dictionary<string, dynamic>
-			{
-				{ nameof(SchoolApplyingToConvert.SchoolHasConsultedStakeholders), SchoolConsultationStakeholders == SelectOption.Yes },
-				{ nameof(SchoolApplyingToConvert.SchoolPlanToConsultStakeholders), SchoolConsultationStakeholdersConsult }
-			};
+			//var dictionaryMapper = new Dictionary<string, dynamic>
+			//{
+			//	{ nameof(SchoolApplyingToConvert.SchoolHasConsultedStakeholders), SchoolConsultationStakeholders == SelectOption.Yes },
+			//	{ nameof(SchoolApplyingToConvert.SchoolPlanToConsultStakeholders), SchoolConsultationStakeholdersConsult }
+			//};
+
+			var dictionaryMapper = PopulateUpdateDictionary();
 
 			await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);
 
@@ -133,7 +135,23 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 	///<inheritdoc/>
 	public override Dictionary<string, dynamic> PopulateUpdateDictionary()
 	{
-		// TODO
+		// if school NOT consulted blank out 'SchoolConsultationStakeholdersConsult'
+		if (SchoolConsultationStakeholders == SelectOption.No)
+		{
+			return new Dictionary<string, dynamic>
+			{
+				{ nameof(SchoolApplyingToConvert.SchoolHasConsultedStakeholders), false },
+				{ nameof(SchoolApplyingToConvert.SchoolPlanToConsultStakeholders), null }
+			};
+		}
+		else
+		{
+			return new Dictionary<string, dynamic>
+			{
+				{ nameof(SchoolApplyingToConvert.SchoolHasConsultedStakeholders), true },
+				{ nameof(SchoolApplyingToConvert.SchoolPlanToConsultStakeholders), SchoolConsultationStakeholdersConsult! }
+			};
+		}
 	}
 
 	private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
@@ -104,12 +104,6 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 			//// grab draft application from temp= null
 			var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
-			//var dictionaryMapper = new Dictionary<string, dynamic>
-			//{
-			//	{ nameof(SchoolApplyingToConvert.SchoolHasConsultedStakeholders), SchoolConsultationStakeholders == SelectOption.Yes },
-			//	{ nameof(SchoolApplyingToConvert.SchoolPlanToConsultStakeholders), SchoolConsultationStakeholdersConsult }
-			//};
-
 			var dictionaryMapper = PopulateUpdateDictionary();
 
 			await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
@@ -124,9 +124,16 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 		}
 	}
 
+	///<inheritdoc/>
 	public override void PopulateValidationMessages()
 	{
 		PopulateViewDataErrorsWithModelStateErrors();
+	}
+
+	///<inheritdoc/>
+	public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+	{
+		// TODO
 	}
 
 	private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultation.cshtml.cs
@@ -129,13 +129,13 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 	///<inheritdoc/>
 	public override Dictionary<string, dynamic> PopulateUpdateDictionary()
 	{
-		// if school NOT consulted blank out 'SchoolConsultationStakeholdersConsult'
+		// if school HAS consulted blank out 'SchoolConsultationStakeholdersConsult'
 		if (SchoolConsultationStakeholders == SelectOption.No)
 		{
 			return new Dictionary<string, dynamic>
 			{
 				{ nameof(SchoolApplyingToConvert.SchoolHasConsultedStakeholders), false },
-				{ nameof(SchoolApplyingToConvert.SchoolPlanToConsultStakeholders), null }
+				{ nameof(SchoolApplyingToConvert.SchoolPlanToConsultStakeholders), SchoolConsultationStakeholdersConsult! }
 			};
 		}
 		else
@@ -143,7 +143,7 @@ public class ApplicationSchoolConsultationModel : BasePageEditModel
 			return new Dictionary<string, dynamic>
 			{
 				{ nameof(SchoolApplyingToConvert.SchoolHasConsultedStakeholders), true },
-				{ nameof(SchoolApplyingToConvert.SchoolPlanToConsultStakeholders), SchoolConsultationStakeholdersConsult! }
+				{ nameof(SchoolApplyingToConvert.SchoolPlanToConsultStakeholders), null }
 			};
 		}
 	}

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
@@ -60,6 +60,13 @@ namespace Dfe.Academies.External.Web.Pages.School
 			PopulateViewDataErrorsWithModelStateErrors();
 		}
 
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// does not apply on this page
+			return new();
+		}
+
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 		{
 			SchoolName = selectedSchool.SchoolName;

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml.cs
@@ -54,6 +54,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();

--- a/Dfe.Academies.External.Web/Pages/School/CurrentFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/CurrentFinancialYear.cshtml.cs
@@ -5,8 +5,6 @@ using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using static GovUk.Frontend.AspNetCore.ComponentDefaults;
 
 namespace Dfe.Academies.External.Web.Pages.School
 {
@@ -226,9 +224,16 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
         {
 	        PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// TODO
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/CurrentFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/CurrentFinancialYear.cshtml.cs
@@ -5,6 +5,7 @@ using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace Dfe.Academies.External.Web.Pages.School
 {
@@ -110,6 +111,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		public DateTime CFYFinancialEndDateLocal { get; set; }
+
 		public CurrentFinancialYearModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService, 
 										IReferenceDataRetrievalService referenceDataRetrievalService,
 										ILogger<CurrentFinancialYearModel> logger,
@@ -145,12 +148,12 @@ namespace Dfe.Academies.External.Web.Pages.School
 		public async Task<IActionResult> OnPostAsync(IFormCollection form)
 		{
 			// MR:- try and build a date from component parts !!!
-			var CFYEndDateComponents = RetrieveDateTimeComponentsFromDatePicker(form, CFYEndDateFormInputName);
-			var CFYEndDateComponentDay = CFYEndDateComponents.FirstOrDefault(x => x.Key == "day").Value;
-			var CFYEndDateComponentMonth = CFYEndDateComponents.FirstOrDefault(x => x.Key == "month").Value;
-			var CFYEndDateComponentYear = CFYEndDateComponents.FirstOrDefault(x => x.Key == "year").Value;
+			var cfyEndDateComponents = RetrieveDateTimeComponentsFromDatePicker(form, CFYEndDateFormInputName);
+			string CFYEndDateComponentDay = cfyEndDateComponents.FirstOrDefault(x => x.Key == "day").Value;
+			string CFYEndDateComponentMonth = cfyEndDateComponents.FirstOrDefault(x => x.Key == "month").Value;
+			string CFYEndDateComponentYear = cfyEndDateComponents.FirstOrDefault(x => x.Key == "year").Value;
 
-			var CFYEndDate = BuildDateTime(CFYEndDateComponentDay, CFYEndDateComponentMonth, CFYEndDateComponentYear);
+			CFYFinancialEndDateLocal = BuildDateTime(CFYEndDateComponentDay, CFYEndDateComponentMonth, CFYEndDateComponentYear);
 
 			if (!ModelState.IsValid)
 			{
@@ -161,7 +164,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 				return Page();
 			}
 
-			if (CFYEndDate == DateTime.MinValue)
+			if (CFYFinancialEndDateLocal == DateTime.MinValue)
 			{
 				ModelState.AddModelError("CFYFinancialEndDateNotEntered", "You must input a valid date");
 				PopulateValidationMessages();
@@ -192,24 +195,10 @@ namespace Dfe.Academies.External.Web.Pages.School
 			{
 				//// grab draft application from temp= null
 				var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
-
-				var currentFinancialYear = new SchoolFinancialYear(CFYEndDate, 
-																		Revenue, 
-																		CFYRevenueStatus, 
-																		CFYRevenueStatusExplained, 
-																		null,
-																		CapitalCarryForward,
-																		CFYCapitalCarryForwardStatus,
-																		CFYCapitalCarryForwardExplained,
-																		null);
-
-				var propertiesToPopulate =
-					new Dictionary<string, dynamic>
-					{
-						{nameof(SchoolApplyingToConvert.CurrentFinancialYear), currentFinancialYear}
-					};
 				
-				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, propertiesToPopulate);
+				var dictionaryMapper = PopulateUpdateDictionary();
+
+				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);
 
 				// update temp store for next step - application overview
 				TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
@@ -233,7 +222,29 @@ namespace Dfe.Academies.External.Web.Pages.School
 		///<inheritdoc/>
 		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
 		{
-			// TODO
+			// if 'CFYRevenueStatus' == Surplus, blank out 'CFYRevenueStatusExplained'
+			if (CFYRevenueStatus == RevenueType.Surplus)
+			{
+				CFYRevenueStatusExplained = null;
+			}
+
+			// if 'CFYCapitalCarryForwardStatus' == Surplus, blank out 'CFYCapitalCarryForwardExplained'
+			if (CFYCapitalCarryForwardStatus == RevenueType.Surplus)
+			{
+				CFYCapitalCarryForwardExplained = null;
+			}
+
+			var currentFinancialYear = new SchoolFinancialYear(CFYFinancialEndDateLocal,
+				Revenue,
+				CFYRevenueStatus,
+				CFYRevenueStatusExplained,
+				null,
+				CapitalCarryForward,
+				CFYCapitalCarryForwardStatus,
+				CFYCapitalCarryForwardExplained,
+				null);
+
+			return new Dictionary<string, dynamic> { {nameof(SchoolApplyingToConvert.CurrentFinancialYear), currentFinancialYear} };
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/Declaration.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/Declaration.cshtml.cs
@@ -94,9 +94,17 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// does not apply on this page
+			return new();
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/DeclarationSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/DeclarationSummary.cshtml.cs
@@ -53,9 +53,17 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// does not apply on this page
+			return new();
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/FinancesReview.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/FinancesReview.cshtml.cs
@@ -54,12 +54,20 @@ namespace Dfe.Academies.External.Web.Pages.School
 		    }
 	    }
 
-	    public override void PopulateValidationMessages()
+		///<inheritdoc/>
+		public override void PopulateValidationMessages()
 	    {
 		    PopulateViewDataErrorsWithModelStateErrors();
 	    }
 
-	    private FinancesReviewHeadingViewModel PopulatePreviousFinancialYear(SchoolApplyingToConvert selectedSchool)
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// does not apply on this page
+			return new();
+		}
+
+		private FinancesReviewHeadingViewModel PopulatePreviousFinancialYear(SchoolApplyingToConvert selectedSchool)
 	    {
 		     var previousFinancialYear = selectedSchool.PreviousFinancialYear;
 

--- a/Dfe.Academies.External.Web/Pages/School/FinancialInvestigations.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/FinancialInvestigations.cshtml.cs
@@ -128,15 +128,17 @@ namespace Dfe.Academies.External.Web.Pages.School
 				//// grab draft application from temp= null
 				var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
-				var propertiesToPopulate =
-					new Dictionary<string, dynamic>
-					{
-						{nameof(SchoolApplyingToConvert.FinanceOngoingInvestigations), FinanceOngoingInvestigations == SelectOption.Yes},
-						{nameof(SchoolApplyingToConvert.FinancialInvestigationsExplain), FinancialInvestigationsExplain!},
-						{nameof(SchoolApplyingToConvert.FinancialInvestigationsTrustAware), FinancialInvestigationsTrustAware == SelectOption.Yes},
-					};
+				var dictionaryMapper = PopulateUpdateDictionary();
 
-				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, propertiesToPopulate);
+				//var propertiesToPopulate =
+				//	new Dictionary<string, dynamic>
+				//	{
+				//		{nameof(SchoolApplyingToConvert.FinanceOngoingInvestigations), FinanceOngoingInvestigations == SelectOption.Yes},
+				//		{nameof(SchoolApplyingToConvert.FinancialInvestigationsExplain), FinancialInvestigationsExplain!},
+				//		{nameof(SchoolApplyingToConvert.FinancialInvestigationsTrustAware), FinancialInvestigationsTrustAware == SelectOption.Yes},
+				//	};
+
+				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);
 
 				// update temp store for next step - application overview
 				TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
@@ -154,6 +156,30 @@ namespace Dfe.Academies.External.Web.Pages.School
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// if FinanceOngoingInvestigations == no, clear FinancialInvestigationsExplain && FinancialInvestigationsTrustAware
+			if (FinanceOngoingInvestigations == SelectOption.No)
+			{
+				return new Dictionary<string, dynamic>
+				{
+					{nameof(SchoolApplyingToConvert.FinanceOngoingInvestigations), false},
+					{nameof(SchoolApplyingToConvert.FinancialInvestigationsExplain), null},
+					{nameof(SchoolApplyingToConvert.FinancialInvestigationsTrustAware), null},
+				};
+			}
+			else
+			{
+				return new Dictionary<string, dynamic>
+					{
+						{nameof(SchoolApplyingToConvert.FinanceOngoingInvestigations), true},
+						{nameof(SchoolApplyingToConvert.FinancialInvestigationsExplain), FinancialInvestigationsExplain!},
+						{nameof(SchoolApplyingToConvert.FinancialInvestigationsTrustAware), FinancialInvestigationsTrustAware == SelectOption.Yes},
+					};
+			}
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/FinancialInvestigations.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/FinancialInvestigations.cshtml.cs
@@ -150,6 +150,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml.cs
@@ -156,7 +156,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
-		public DateTime WorksPlannedDateLocal { get; set; }
+		public DateTime? WorksPlannedDateLocal { get; set; }
 
 		public LandAndBuildingsModel(ILogger<LandAndBuildingsModel> logger,
 			IConversionApplicationRetrievalService conversionApplicationRetrievalService,
@@ -278,10 +278,11 @@ namespace Dfe.Academies.External.Web.Pages.School
 		///<inheritdoc/>
 		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
 		{
-			// if this.SchoolBuildLandWorksPlanned == 'no', blank out 'SchoolBuildLandWorksPlannedExplained'
+			// if this.SchoolBuildLandWorksPlanned == 'no', blank out 'SchoolBuildLandWorksPlannedExplained' && works planned date
 			if (this.SchoolBuildLandWorksPlanned == SelectOption.No)
 			{
 				this.SchoolBuildLandWorksPlannedExplained = null;
+				WorksPlannedDateLocal = null;
 			}
 
 			// if this.SchoolBuildLandSharedFacilities == 'no', blank out 'SchoolBuildLandSharedFacilitiesExplained'

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml.cs
@@ -286,9 +286,16 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// TODO
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using Dfe.Academies.External.Web.Attributes;
 using Dfe.Academies.External.Web.Enums;
 using Dfe.Academies.External.Web.Models;
@@ -157,6 +156,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		public DateTime WorksPlannedDateLocal { get; set; }
+
 		public LandAndBuildingsModel(ILogger<LandAndBuildingsModel> logger,
 			IConversionApplicationRetrievalService conversionApplicationRetrievalService,
 			IReferenceDataRetrievalService referenceDataRetrievalService,
@@ -193,11 +194,11 @@ namespace Dfe.Academies.External.Web.Pages.School
 		{
 			// MR:- try and build a date from component parts !!!
 			var dateComponents = RetrieveDateTimeComponentsFromDatePicker(form, PlannedDateFormInputName);
-			var day = dateComponents.FirstOrDefault(x => x.Key == "day").Value;
-			var month = dateComponents.FirstOrDefault(x => x.Key == "month").Value;
-			var year = dateComponents.FirstOrDefault(x => x.Key == "year").Value;
+			string day = dateComponents.FirstOrDefault(x => x.Key == "day").Value;
+			string month = dateComponents.FirstOrDefault(x => x.Key == "month").Value;
+			string year = dateComponents.FirstOrDefault(x => x.Key == "year").Value;
 
-			var plannedDate = BuildDateTime(day, month, year);
+			WorksPlannedDateLocal = BuildDateTime(day, month, year);
 
 			if (!ModelState.IsValid)
 			{
@@ -215,7 +216,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 				return Page();
 			}
 
-			if (SchoolBuildLandWorksPlanned == SelectOption.Yes && plannedDate == DateTime.MinValue)
+			if (SchoolBuildLandWorksPlanned == SelectOption.Yes && WorksPlannedDateLocal == DateTime.MinValue)
 			{
 				ModelState.AddModelError("SchoolBuildLandWorksPlannedDateNotEntered", "You must input a valid date");
 				PopulateValidationMessages();
@@ -252,26 +253,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 				//// grab draft application from temp= null
 				var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
-				var landAndBuildingsData = new SchoolLandAndBuildings(
-					this.SchoolBuildLandOwnerExplained,
-					this.SchoolBuildLandWorksPlanned == SelectOption.Yes,
-					this.SchoolBuildLandWorksPlannedExplained,
-					plannedDate,
-					this.SchoolBuildLandSharedFacilities == SelectOption.Yes,
-					this.SchoolBuildLandSharedFacilitiesExplained,
-					this.SchoolBuildLandGrants == SelectOption.Yes,
-					this.SchoolBuildLandGrantsBodies,
-					this.SchoolBuildLandPFIScheme == SelectOption.Yes,
-					this.SchoolBuildLandPFISchemeType,
-					this.SchoolBuildLandPriorityBuildingProgramme == SelectOption.Yes,
-					this.SchoolBuildLandFutureProgramme == SelectOption.Yes
-				);
+				var dictionaryMapper = PopulateUpdateDictionary();
 
-				var dictionaryMapper = new Dictionary<string, dynamic>
-				{
-					{ nameof(SchoolApplyingToConvert.LandAndBuildings), landAndBuildingsData }
-				};
-				
 				await _academisationCreationService.PutSchoolApplicationDetails( ApplicationId, this.Urn, dictionaryMapper);
 
 				// update temp store for next step - application overview
@@ -295,7 +278,40 @@ namespace Dfe.Academies.External.Web.Pages.School
 		///<inheritdoc/>
 		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
 		{
-			// TODO
+			// if this.SchoolBuildLandWorksPlanned == 'no', blank out 'SchoolBuildLandWorksPlannedExplained'
+			if (this.SchoolBuildLandWorksPlanned == SelectOption.No)
+			{
+				this.SchoolBuildLandWorksPlannedExplained = null;
+			}
+
+			// if this.SchoolBuildLandSharedFacilities == 'no', blank out 'SchoolBuildLandSharedFacilitiesExplained'
+			if (this.SchoolBuildLandSharedFacilities == SelectOption.No)
+			{
+				this.SchoolBuildLandSharedFacilitiesExplained = null;
+			}
+
+			// if this.SchoolBuildLandPFIScheme == 'no', blank out 'SchoolBuildLandPFISchemeType'
+			if (this.SchoolBuildLandPFIScheme == SelectOption.No)
+			{
+				this.SchoolBuildLandPFISchemeType = null;
+			}
+
+			var landAndBuildingsData = new SchoolLandAndBuildings(
+				this.SchoolBuildLandOwnerExplained,
+				this.SchoolBuildLandWorksPlanned == SelectOption.Yes,
+				this.SchoolBuildLandWorksPlannedExplained,
+				WorksPlannedDateLocal,
+				this.SchoolBuildLandSharedFacilities == SelectOption.Yes,
+				this.SchoolBuildLandSharedFacilitiesExplained,
+				this.SchoolBuildLandGrants == SelectOption.Yes,
+				this.SchoolBuildLandGrantsBodies,
+				this.SchoolBuildLandPFIScheme == SelectOption.Yes,
+				this.SchoolBuildLandPFISchemeType,
+				this.SchoolBuildLandPriorityBuildingProgramme == SelectOption.Yes,
+				this.SchoolBuildLandFutureProgramme == SelectOption.Yes
+			);
+
+			return new Dictionary<string, dynamic> { { nameof(SchoolApplyingToConvert.LandAndBuildings), landAndBuildingsData } };
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
@@ -112,57 +112,58 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			heading1.Sections.Add(new(
 				SchoolLandAndBuildingsSummarySectionViewModel.SharedFacilities,
-				(landAndBuildings.FacilitiesShared.GetStringDescription())
+				landAndBuildings.FacilitiesShared.GetStringDescription()
 			)
 			{
 				SubQuestionAndAnswers = new()
 				{
 					new SchoolLandAndBuildingsSummarySectionViewModel(
 						SchoolLandAndBuildingsSummarySectionViewModel.SharedFacilitiesList,
-						landAndBuildings.FacilitiesSharedExplained ??
-						QuestionAndAnswerConstants.NoAnswer
-					)
+						!string.IsNullOrWhiteSpace(landAndBuildings.FacilitiesSharedExplained) ?
+							landAndBuildings.FacilitiesSharedExplained :
+							QuestionAndAnswerConstants.NoAnswer)
 				}
 			});
 
 			heading1.Sections.Add(new(
 				SchoolLandAndBuildingsSummarySectionViewModel.Grants,
-				(landAndBuildings.Grants.GetStringDescription())
+				landAndBuildings.Grants.GetStringDescription()
 			)
 			{
 				SubQuestionAndAnswers = new()
 				{
 					new SchoolLandAndBuildingsSummarySectionViewModel(
 						SchoolLandAndBuildingsSummarySectionViewModel.GrantBodies,
-						landAndBuildings.GrantsAwardingBodies ??
-						QuestionAndAnswerConstants.NoAnswer
-					)
+						!string.IsNullOrWhiteSpace(landAndBuildings.GrantsAwardingBodies) ?
+							landAndBuildings.GrantsAwardingBodies :
+							QuestionAndAnswerConstants.NoAnswer)
 				}
 			});
 
 			heading1.Sections.Add(new(
 				SchoolLandAndBuildingsSummarySectionViewModel.PFI,
-				(landAndBuildings.PartOfPFIScheme.GetStringDescription())
+				landAndBuildings.PartOfPFIScheme.GetStringDescription()
 			)
 			{
 				SubQuestionAndAnswers = new()
 				{
 					new SchoolLandAndBuildingsSummarySectionViewModel(
 						SchoolLandAndBuildingsSummarySectionViewModel.PFIKind,
-						landAndBuildings.PartOfPFISchemeType ??
-						QuestionAndAnswerConstants.NoAnswer)
+						!string.IsNullOrWhiteSpace(landAndBuildings.PartOfPFISchemeType) ?
+							landAndBuildings.PartOfPFISchemeType :
+							QuestionAndAnswerConstants.NoAnswer)
 				}
 			});
 
 			heading1.Sections.Add(new(
 					SchoolLandAndBuildingsSummarySectionViewModel.PrioritySchoolBuildingProgram,
-					(landAndBuildings.PartOfPrioritySchoolsBuildingProgramme.GetStringDescription())
+					landAndBuildings.PartOfPrioritySchoolsBuildingProgramme.GetStringDescription()
 				)
 			);
 
 			heading1.Sections.Add(new(
 					SchoolLandAndBuildingsSummarySectionViewModel.BuildingSchoolsForTheFuture,
-					(landAndBuildings.PartOfBuildingSchoolsForFutureProgramme.GetStringDescription())
+					landAndBuildings.PartOfBuildingSchoolsForFutureProgramme.GetStringDescription()
 				)
 			);
 

--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildingsSummary.cshtml.cs
@@ -54,9 +54,17 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// does not apply on this page
+			return new();
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/LoanDetails.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LoanDetails.cshtml.cs
@@ -38,6 +38,11 @@ namespace Dfe.Academies.External.Web.Pages.School
 		[BindProperty]
 		public bool IsDraft { get; set; }
 
+		public LoanDetails(IConversionApplicationRetrievalService conversionApplicationRetrievalService, IReferenceDataRetrievalService referenceDataRetrievalService) 
+			: base(conversionApplicationRetrievalService, referenceDataRetrievalService)
+		{
+		}
+
 		public void OnGet(int appId, int urn, int id, bool isEdit)
 		{
 			LoadAndStoreCachedConversionApplication();
@@ -64,10 +69,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 					RepaymentSchedule = selectedLoan.RepaymentSchedule;
 				}
 			}
-		}
-		public override void PopulateValidationMessages()
-		{
-			PopulateViewDataErrorsWithModelStateErrors();
 		}
 
 		public async Task<IActionResult> OnPostAsync()
@@ -118,8 +119,17 @@ namespace Dfe.Academies.External.Web.Pages.School
 			return RedirectToPage( "Loans" ,new {urn = Urn, appId = ApplicationId});
 		}
 
-		public LoanDetails(IConversionApplicationRetrievalService conversionApplicationRetrievalService, IReferenceDataRetrievalService referenceDataRetrievalService) : base(conversionApplicationRetrievalService, referenceDataRetrievalService)
+		///<inheritdoc/>
+		public override void PopulateValidationMessages()
 		{
+			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// does not apply on this page
+			return new();
 		}
 	}
 }

--- a/Dfe.Academies.External.Web/Pages/School/Loans.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/Loans.cshtml.cs
@@ -5,8 +5,6 @@ using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
 using Dfe.Academies.External.Web.ViewModels;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Dfe.Academies.External.Web.Pages.School
 {
@@ -91,6 +89,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 			{
 				{ nameof(SchoolApplyingToConvert.Loans), loans }
 			};
+
 			await _academisationCreationService.PutSchoolApplicationDetails(
 				ApplicationId,
 				Urn,
@@ -175,16 +174,24 @@ namespace Dfe.Academies.External.Web.Pages.School
 			});
 			TempDataSetLoanViewModels(Urn, LoanViewModels);
 		}
+		
+		///<inheritdoc/>
+		public override void PopulateValidationMessages()
+		{
+			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// does not apply on this page
+			return new();
+		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 		{
 			SchoolName = selectedSchool.SchoolName;
 			AnyLoans = LoanViewModels.Any() ? SelectOption.Yes : SelectOption.No;
-		}
-		
-		public override void PopulateValidationMessages()
-		{
-			PopulateViewDataErrorsWithModelStateErrors();
 		}
 	}
 }

--- a/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml.cs
@@ -228,18 +228,16 @@ public class NextFinancialYearModel : BasePageEditModel
     ///<inheritdoc/>
     public override Dictionary<string, dynamic> PopulateUpdateDictionary()
     {
-		// TODO
-
 		// if 'NFYRevenueStatus' == Surplus, blank out 'PFYRevenueStatusExplained'
 		if (NFYRevenueStatus == RevenueType.Surplus)
 		{
-			PFYRevenueStatusExplained = null;
+			NFYRevenueStatusExplained = null;
 		}
 
 		// if 'NFYCapitalCarryForwardStatus' == Surplus, blank out 'PFYCapitalCarryForwardExplained'
 		if (NFYCapitalCarryForwardStatus == RevenueType.Surplus)
 		{
-			PFYCapitalCarryForwardExplained = null;
+			NFYCapitalCarryForwardExplained = null;
 		}
 
 		var nextFinancialYear = new SchoolFinancialYear(NFYFinancialEndDateLocal,

--- a/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml.cs
@@ -231,10 +231,17 @@ public class NextFinancialYearModel : BasePageEditModel
 		}
 	}
 
-    public override void PopulateValidationMessages()
+    ///<inheritdoc/>
+	public override void PopulateValidationMessages()
 	{
 		PopulateViewDataErrorsWithModelStateErrors();
 	}
+
+    ///<inheritdoc/>
+    public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+    {
+	    // TODO
+    }
 
 	private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 	{

--- a/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/NextFinancialYear.cshtml.cs
@@ -118,6 +118,8 @@ public class NextFinancialYearModel : BasePageEditModel
 		}
 	}
 
+	public DateTime NFYFinancialEndDateLocal { get; set; }
+
 	public NextFinancialYearModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService,
 	    IReferenceDataRetrievalService referenceDataRetrievalService,
 	    ILogger<NextFinancialYearModel> logger,
@@ -153,12 +155,12 @@ public class NextFinancialYearModel : BasePageEditModel
     public async Task<IActionResult> OnPostAsync(IFormCollection form)
     {
 	    // MR:- try and build a date from component parts !!!
-	    var NFYEndDateComponents = RetrieveDateTimeComponentsFromDatePicker(form, NFYEndDateFormInputName);
-	    var NFYEndDateComponentDay = NFYEndDateComponents.FirstOrDefault(x => x.Key == "day").Value;
-	    var NFYEndDateComponentMonth = NFYEndDateComponents.FirstOrDefault(x => x.Key == "month").Value;
-	    var NFYEndDateComponentYear = NFYEndDateComponents.FirstOrDefault(x => x.Key == "year").Value;
+	    var nfyEndDateComponents = RetrieveDateTimeComponentsFromDatePicker(form, NFYEndDateFormInputName);
+	    string NFYEndDateComponentDay = nfyEndDateComponents.FirstOrDefault(x => x.Key == "day").Value;
+	    string NFYEndDateComponentMonth = nfyEndDateComponents.FirstOrDefault(x => x.Key == "month").Value;
+	    string NFYEndDateComponentYear = nfyEndDateComponents.FirstOrDefault(x => x.Key == "year").Value;
 
-	    var NFYEndDate = BuildDateTime(NFYEndDateComponentDay, NFYEndDateComponentMonth, NFYEndDateComponentYear);
+	    NFYFinancialEndDateLocal = BuildDateTime(NFYEndDateComponentDay, NFYEndDateComponentMonth, NFYEndDateComponentYear);
 
 	    if (!ModelState.IsValid)
 	    {
@@ -169,7 +171,7 @@ public class NextFinancialYearModel : BasePageEditModel
 		    return Page();
 	    }
 
-	    if (NFYEndDate == DateTime.MinValue)
+	    if (NFYFinancialEndDateLocal == DateTime.MinValue)
 	    {
 		    ModelState.AddModelError("NFYFinancialEndDateNotEntered", "You must input a valid date");
 		    PopulateValidationMessages();
@@ -201,23 +203,9 @@ public class NextFinancialYearModel : BasePageEditModel
 			//// grab draft application from temp= null
 			var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
-			var nextFinancialYear = new SchoolFinancialYear(NFYEndDate,
-				Revenue,
-				NFYRevenueStatus,
-				NFYRevenueStatusExplained,
-				null,
-				CapitalCarryForward,
-				NFYCapitalCarryForwardStatus,
-				NFYCapitalCarryForwardExplained,
-				null);
+			var dictionaryMapper = PopulateUpdateDictionary();
 
-			var propertiesToPopulate =
-				new Dictionary<string, dynamic>
-				{
-					{nameof(SchoolApplyingToConvert.NextFinancialYear), nextFinancialYear}
-				};
-
-			await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, propertiesToPopulate);
+			await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);
 
 			// update temp store for next step - application overview
 			TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
@@ -240,8 +228,32 @@ public class NextFinancialYearModel : BasePageEditModel
     ///<inheritdoc/>
     public override Dictionary<string, dynamic> PopulateUpdateDictionary()
     {
-	    // TODO
-    }
+		// TODO
+
+		// if 'NFYRevenueStatus' == Surplus, blank out 'PFYRevenueStatusExplained'
+		if (NFYRevenueStatus == RevenueType.Surplus)
+		{
+			PFYRevenueStatusExplained = null;
+		}
+
+		// if 'NFYCapitalCarryForwardStatus' == Surplus, blank out 'PFYCapitalCarryForwardExplained'
+		if (NFYCapitalCarryForwardStatus == RevenueType.Surplus)
+		{
+			PFYCapitalCarryForwardExplained = null;
+		}
+
+		var nextFinancialYear = new SchoolFinancialYear(NFYFinancialEndDateLocal,
+			Revenue,
+			NFYRevenueStatus,
+			NFYRevenueStatusExplained,
+			null,
+			CapitalCarryForward,
+			NFYCapitalCarryForwardStatus,
+			NFYCapitalCarryForwardExplained,
+			null);
+
+		return new Dictionary<string, dynamic> { {nameof(SchoolApplyingToConvert.NextFinancialYear), nextFinancialYear} };
+	}
 
 	private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 	{
@@ -249,6 +261,7 @@ public class NextFinancialYearModel : BasePageEditModel
 		NFYEndDate = (selectedSchool.NextFinancialYear.FinancialYearEndDate.HasValue ?
 			selectedSchool.NextFinancialYear.FinancialYearEndDate.Value.ToString("dd/MM/yyyy")
 			: string.Empty);
+
 		// Revenue
 		if (selectedSchool.NextFinancialYear.Revenue != null)
 		{
@@ -261,6 +274,7 @@ public class NextFinancialYearModel : BasePageEditModel
 		}
 
 		NFYRevenueStatusExplained = selectedSchool.NextFinancialYear.RevenueStatusExplained;
+
 		// CCF
 		if (selectedSchool.NextFinancialYear.CapitalCarryForward != null)
 		{

--- a/Dfe.Academies.External.Web/Pages/School/PreviousFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/PreviousFinancialYear.cshtml.cs
@@ -231,9 +231,16 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
         {
 	        PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// TODO
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/PreviousFinancialYear.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/PreviousFinancialYear.cshtml.cs
@@ -119,6 +119,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		public DateTime PFYFinancialEndDateLocal { get; set; }
+
 		public PreviousFinancialYearModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService, 
 										IReferenceDataRetrievalService referenceDataRetrievalService,
 										ILogger<PreviousFinancialYearModel> logger,
@@ -154,12 +156,12 @@ namespace Dfe.Academies.External.Web.Pages.School
 		public async Task<IActionResult> OnPostAsync(IFormCollection form)
 		{
 			// MR:- try and build a date from component parts !!!
-			var PFYEndDateComponents = RetrieveDateTimeComponentsFromDatePicker(form, PFYEndDateFormInputName);
-			var PFYEndDateComponentDay = PFYEndDateComponents.FirstOrDefault(x => x.Key == "day").Value;
-			var PFYEndDateComponentMonth = PFYEndDateComponents.FirstOrDefault(x => x.Key == "month").Value;
-			var PFYEndDateComponentYear = PFYEndDateComponents.FirstOrDefault(x => x.Key == "year").Value;
+			var pfyEndDateComponents = RetrieveDateTimeComponentsFromDatePicker(form, PFYEndDateFormInputName);
+			string PFYEndDateComponentDay = pfyEndDateComponents.FirstOrDefault(x => x.Key == "day").Value;
+			string PFYEndDateComponentMonth = pfyEndDateComponents.FirstOrDefault(x => x.Key == "month").Value;
+			string PFYEndDateComponentYear = pfyEndDateComponents.FirstOrDefault(x => x.Key == "year").Value;
 
-			var PFYEndDate = BuildDateTime(PFYEndDateComponentDay, PFYEndDateComponentMonth, PFYEndDateComponentYear);
+			PFYFinancialEndDateLocal = BuildDateTime(PFYEndDateComponentDay, PFYEndDateComponentMonth, PFYEndDateComponentYear);
 
 			if (!ModelState.IsValid)
 			{
@@ -170,7 +172,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 				return Page();
 			}
 
-			if (PFYEndDate == DateTime.MinValue)
+			if (PFYFinancialEndDateLocal == DateTime.MinValue)
 			{
 				ModelState.AddModelError("PFYFinancialEndDateNotEntered", "You must input a valid date");
 				PopulateValidationMessages();
@@ -204,19 +206,22 @@ namespace Dfe.Academies.External.Web.Pages.School
 					TempDataHelper.GetSerialisedValue<ConversionApplication>(
 						TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
-				var previousFinancialYear = new SchoolFinancialYear(PFYEndDate,
-					Revenue,
-					PFYRevenueStatus,
-					PFYRevenueStatusExplained,
-					null,
-					CapitalCarryForward,
-					PFYCapitalCarryForwardStatus,
-					PFYCapitalCarryForwardExplained,
-					null);
+				//var previousFinancialYear = new SchoolFinancialYear(PFYFinancialEndDateLocal,
+				//	Revenue,
+				//	PFYRevenueStatus,
+				//	PFYRevenueStatusExplained,
+				//	null,
+				//	CapitalCarryForward,
+				//	PFYCapitalCarryForwardStatus,
+				//	PFYCapitalCarryForwardExplained,
+				//	null);
 
-				var mappingDictionary =
-					new Dictionary<string, dynamic> { { nameof(SchoolApplyingToConvert.PreviousFinancialYear), previousFinancialYear } };
-				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, mappingDictionary);
+				//var mappingDictionary =
+				//	new Dictionary<string, dynamic> { { nameof(SchoolApplyingToConvert.PreviousFinancialYear), previousFinancialYear } };
+
+				var dictionaryMapper = PopulateUpdateDictionary();
+
+				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);
 
 				// update temp store for next step - application overview
 				TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
@@ -240,7 +245,29 @@ namespace Dfe.Academies.External.Web.Pages.School
 		///<inheritdoc/>
 		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
 		{
-			// TODO
+			// if 'PFYRevenueStatus' == Surplus, blank out 'PFYRevenueStatusExplained'
+			if (PFYRevenueStatus == RevenueType.Surplus)
+			{
+				PFYRevenueStatusExplained = null;
+			}
+
+			// if 'PFYCapitalCarryForwardStatus' == Surplus, blank out 'PFYCapitalCarryForwardExplained'
+			if (PFYCapitalCarryForwardStatus == RevenueType.Surplus)
+			{
+				PFYCapitalCarryForwardExplained = null;
+			}
+
+			var previousFinancialYear = new SchoolFinancialYear(PFYFinancialEndDateLocal,
+				Revenue,
+				PFYRevenueStatus,
+				PFYRevenueStatusExplained,
+				null,
+				CapitalCarryForward,
+				PFYCapitalCarryForwardStatus,
+				PFYCapitalCarryForwardExplained,
+				null);
+
+			return new Dictionary<string, dynamic> { { nameof(SchoolApplyingToConvert.PreviousFinancialYear), previousFinancialYear } };
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
@@ -249,6 +276,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 			PFYEndDate = (selectedSchool.PreviousFinancialYear.FinancialYearEndDate.HasValue ?
 				selectedSchool.PreviousFinancialYear.FinancialYearEndDate.Value.ToString("dd/MM/yyyy")
 				: string.Empty);
+
 			// Revenue
 			if (selectedSchool.PreviousFinancialYear.Revenue != null)
 			{
@@ -261,6 +289,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 
 			PFYRevenueStatusExplained = selectedSchool.PreviousFinancialYear.RevenueStatusExplained;
+
 			// CCF
 			if (selectedSchool.PreviousFinancialYear.CapitalCarryForward != null)
 			{

--- a/Dfe.Academies.External.Web/Pages/School/PupilNumbers.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/PupilNumbers.cshtml.cs
@@ -96,6 +96,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 					{ nameof(SchoolApplyingToConvert.SchoolCapacityAssumptions), SchoolCapacityAssumptions },
 					{ nameof(SchoolApplyingToConvert.SchoolCapacityPublishedAdmissionsNumber), SchoolCapacityPublishedAdmissionsNumber.Value },
 				};
+
 				await _academisationCreationService.PutSchoolApplicationDetails(
 					ApplicationId,
 					Urn,
@@ -114,9 +115,16 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// TODO
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/PupilNumbers.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/PupilNumbers.cshtml.cs
@@ -41,8 +41,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 		[BindProperty]
 		[Required(ErrorMessage = "You must tell us what your projected pupil numbers are based on")]
 		public string? SchoolCapacityAssumptions { get; set; } = string.Empty;
-
-
+		
 		public PupilNumbersModel(ILogger<PupilNumbersModel> logger,
 								IConversionApplicationRetrievalService conversionApplicationRetrievalService,
 								IReferenceDataRetrievalService referenceDataRetrievalService,
@@ -88,20 +87,9 @@ namespace Dfe.Academies.External.Web.Pages.School
 				//// grab draft application from temp= null
 				var draftConversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
 
-				var dictionaryMapper = new Dictionary<string, dynamic>
-				{
-					{ nameof(SchoolApplyingToConvert.ProjectedPupilNumbersYear1), ProjectedPupilNumbersYear1.Value },
-					{ nameof(SchoolApplyingToConvert.ProjectedPupilNumbersYear2), ProjectedPupilNumbersYear2.Value },
-					{ nameof(SchoolApplyingToConvert.ProjectedPupilNumbersYear3), ProjectedPupilNumbersYear3.Value },
-					{ nameof(SchoolApplyingToConvert.SchoolCapacityAssumptions), SchoolCapacityAssumptions },
-					{ nameof(SchoolApplyingToConvert.SchoolCapacityPublishedAdmissionsNumber), SchoolCapacityPublishedAdmissionsNumber.Value },
-				};
-
-				await _academisationCreationService.PutSchoolApplicationDetails(
-					ApplicationId,
-					Urn,
-					dictionaryMapper
-					);
+				var dictionaryMapper = PopulateUpdateDictionary();
+				
+				await _academisationCreationService.PutSchoolApplicationDetails(ApplicationId, Urn, dictionaryMapper);
 
 				// update temp store for next step - application overview
 				TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
@@ -124,7 +112,16 @@ namespace Dfe.Academies.External.Web.Pages.School
 		///<inheritdoc/>
 		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
 		{
-			// TODO
+			// no radios / optional inputs on this form !!!
+
+			return new Dictionary<string, dynamic>
+			{
+				{ nameof(SchoolApplyingToConvert.ProjectedPupilNumbersYear1), ProjectedPupilNumbersYear1!.Value },
+				{ nameof(SchoolApplyingToConvert.ProjectedPupilNumbersYear2), ProjectedPupilNumbersYear2!.Value },
+				{ nameof(SchoolApplyingToConvert.ProjectedPupilNumbersYear3), ProjectedPupilNumbersYear3!.Value },
+				{ nameof(SchoolApplyingToConvert.SchoolCapacityAssumptions), SchoolCapacityAssumptions! },
+				{ nameof(SchoolApplyingToConvert.SchoolCapacityPublishedAdmissionsNumber), SchoolCapacityPublishedAdmissionsNumber!.Value },
+			};
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/PupilNumbersSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/PupilNumbersSummary.cshtml.cs
@@ -53,9 +53,17 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// does not apply on this page
+			return new();
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml.cs
@@ -57,9 +57,17 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// does not apply on this page
+			return new();
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool)

--- a/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml.cs
@@ -205,11 +205,12 @@ namespace Dfe.Academies.External.Web.Pages.School
 					}
 				});
 
-			// TODO MR:- ApplicationJoinTrustReasons not in API yet - 08/09/2022
 			SchoolConversionComponentHeadingViewModel heading4 = new(SchoolConversionComponentHeadingViewModel.HeadingApplicationJoinTrustReason,
 				"/school/ApplicationJoinTrustReasons");
 			heading4.Sections.Add(new(SchoolConversionComponentSectionViewModel.ReasonsForJoiningTrustSectionName,
-				QuestionAndAnswerConstants.NoInfoAnswer
+				!string.IsNullOrWhiteSpace(selectedSchool.ApplicationJoinTrustReason) ?
+					selectedSchool.ApplicationJoinTrustReason
+					: QuestionAndAnswerConstants.NoInfoAnswer
 				));
 
 			SchoolConversionComponentHeadingViewModel heading5 = new(SchoolConversionComponentHeadingViewModel.HeadingApplicationSchoolNameChange,

--- a/Dfe.Academies.External.Web/Pages/School/SchoolMainContacts.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolMainContacts.cshtml.cs
@@ -174,9 +174,16 @@ namespace Dfe.Academies.External.Web.Pages.School
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// TODO
 		}
 
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool, ApplicationTypes applicationType)

--- a/Dfe.Academies.External.Web/Pages/School/SchoolOverview.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolOverview.cshtml.cs
@@ -53,7 +53,20 @@ namespace Dfe.Academies.External.Web.Pages.School
 				_logger.LogError("Application::SchoolOverviewModel::OnGetAsync::Exception - {Message}", ex.Message);
 			}
 		}
+		
+		///<inheritdoc/>
+		public override void PopulateValidationMessages()
+		{
+			PopulateViewDataErrorsWithModelStateErrors();
+		}
 
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// does not apply on this page
+			return new();
+		}
+		
 		private void PopulateUiModel(SchoolApplyingToConvert selectedSchool, ConversionApplication? application)
 		{
 			SchoolName = selectedSchool.SchoolName;
@@ -73,11 +86,6 @@ namespace Dfe.Academies.External.Web.Pages.School
 			};
 
 			SchoolComponents = componentsVm;
-		}
-
-		public override void PopulateValidationMessages()
-		{
-			PopulateViewDataErrorsWithModelStateErrors();
 		}
 	}
 }

--- a/Dfe.Academies.External.Web/Validators/EmailValidator.cs
+++ b/Dfe.Academies.External.Web/Validators/EmailValidator.cs
@@ -1,0 +1,13 @@
+﻿using FluentValidation;
+
+namespace Dfe.Academies.External.Web.Validators;
+
+public sealed class EmailValidator : AbstractValidator<EmailAddress>
+{
+	public EmailValidator()
+	{
+		RuleFor(x => x.Email).EmailAddress();
+	}
+}
+
+public record EmailAddress(string Email);


### PR DESCRIPTION
Resolves following issue:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/107918?McasTsid=26110

Also, added email validation to optional 'MainContactOtherEmail' to show used validation warning

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
On the following 12 pages. if the user selects no for instance, then goes into the page and selects yes, the optional data input is not cleared:-
Join Trust Reasons
Pre-opening support grant
School consultation
Current Financial Year
Financial investigations
Land and buildings
Next financial year
previous financial year
pupil numbers
School contacts
Change School Name
Conversion Target Date

## Steps to reproduce issue (if relevant)
1. Go into one of the affected pages, fill in data, with either yes or no dependent on which option shows the optional data inputs
2. Go into one of the affected pages, fill in data, with either yes or no dependent on which option DOESNT shows the optional data inputs
3. On the associated summary page, the optional data IS showing

## Steps to test this PR
1. Go into one of the affected pages, fill in data, with either yes or no dependent on which option shows the optional data inputs
2. Go into one of the affected pages, fill in data, with either yes or no dependent on which option DOESNT shows the optional data inputs
3. On the associated summary page, the optional data should no longer show

## Prerequisites
n/a