### PR TITLE
v1.5: Name of School Fails to Return On About the conversion page

### DIFF
--- a/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml.cs
@@ -4,7 +4,6 @@ using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
 using Dfe.Academies.External.Web.ViewModels;
-using Microsoft.AspNetCore.Mvc;
 
 namespace Dfe.Academies.External.Web.Pages.School
 {
@@ -55,7 +54,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			heading1.Sections.Add(
 				new(SchoolConversionComponentSectionViewModel.NameOfSchoolSectionName,
-					SchoolName));
+					selectedSchool.SchoolName));
 
 			SchoolConversionComponentHeadingViewModel heading2 =
 				new(SchoolConversionComponentHeadingViewModel.HeadingApplicationContactDetails,


### PR DESCRIPTION
fix this issue:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/109819?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Selected school against application isn't showing on About the conversion page

## Steps to reproduce issue (if relevant)
1. Selected school against application isn't showing on About the conversion page

## Steps to test this PR
1. Selected school against application shows on About the conversion page

## Prerequisites
n/a