### PR TITLE
New land and buildings data causes exception

### DIFF
--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml.cs
@@ -260,20 +260,37 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		public override void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 		{
-			SchoolBuildLandOwnerExplained = selectedSchool.LandAndBuildings.OwnerExplained;
-			SchoolBuildLandWorksPlanned = selectedSchool.LandAndBuildings.WorksPlanned.Value ? SelectOption.Yes : SelectOption.No;
+			SchoolBuildLandOwnerExplained = selectedSchool.LandAndBuildings.OwnerExplained ?? string.Empty;
+			SchoolBuildLandWorksPlanned = selectedSchool.LandAndBuildings.WorksPlanned.HasValue 
+				? (selectedSchool.LandAndBuildings.WorksPlanned.Value ? SelectOption.Yes : SelectOption.No) 
+				: SelectOption.No;
+
 			SchoolBuildLandWorksPlannedExplained = selectedSchool.LandAndBuildings.WorksPlannedExplained;
 			WorksPlannedDate = (selectedSchool.LandAndBuildings.WorksPlannedDate.HasValue ?
 				selectedSchool.LandAndBuildings.WorksPlannedDate.Value.ToString("dd/MM/yyyy")
 				: string.Empty);
-			SchoolBuildLandSharedFacilities = selectedSchool.LandAndBuildings.FacilitiesShared.Value ? SelectOption.Yes : SelectOption.No;
+
+			SchoolBuildLandSharedFacilities = selectedSchool.LandAndBuildings.FacilitiesShared.HasValue
+				? (selectedSchool.LandAndBuildings.FacilitiesShared.Value ? SelectOption.Yes : SelectOption.No)
+				: SelectOption.No;
 			SchoolBuildLandSharedFacilitiesExplained = selectedSchool.LandAndBuildings.FacilitiesSharedExplained;
-			SchoolBuildLandGrants = selectedSchool.LandAndBuildings.Grants.Value ? SelectOption.Yes : SelectOption.No;
+
+			SchoolBuildLandGrants = selectedSchool.LandAndBuildings.Grants.HasValue
+				? (selectedSchool.LandAndBuildings.Grants.Value ? SelectOption.Yes : SelectOption.No)
+				: SelectOption.No;
 			SchoolBuildLandGrantsBodies = selectedSchool.LandAndBuildings.GrantsAwardingBodies;
-			SchoolBuildLandPFIScheme = selectedSchool.LandAndBuildings.PartOfPFIScheme.Value ? SelectOption.Yes : SelectOption.No;
+
+			SchoolBuildLandPFIScheme = selectedSchool.LandAndBuildings.PartOfPFIScheme.HasValue
+				? (selectedSchool.LandAndBuildings.PartOfPFIScheme.Value ? SelectOption.Yes : SelectOption.No)
+				: SelectOption.No;
 			SchoolBuildLandPFISchemeType = selectedSchool.LandAndBuildings.PartOfPFISchemeType;
-			SchoolBuildLandPriorityBuildingProgramme = selectedSchool.LandAndBuildings.PartOfPrioritySchoolsBuildingProgramme.Value ? SelectOption.Yes : SelectOption.No;
-			SchoolBuildLandFutureProgramme = selectedSchool.LandAndBuildings.PartOfBuildingSchoolsForFutureProgramme.Value ? SelectOption.Yes : SelectOption.No;
+
+			SchoolBuildLandPriorityBuildingProgramme = selectedSchool.LandAndBuildings.PartOfPrioritySchoolsBuildingProgramme.HasValue
+				? (selectedSchool.LandAndBuildings.PartOfPrioritySchoolsBuildingProgramme.Value ? SelectOption.Yes : SelectOption.No)
+				: SelectOption.No;
+			SchoolBuildLandFutureProgramme = selectedSchool.LandAndBuildings.PartOfBuildingSchoolsForFutureProgramme.HasValue
+				? (selectedSchool.LandAndBuildings.PartOfBuildingSchoolsForFutureProgramme.Value ? SelectOption.Yes : SelectOption.No)
+				: SelectOption.No;
 		}
 
 		private void RePopDatePickerModel(string worksPlannedDateDay, string worksPlannedDateMonth, string worksPlannedDateYear)


### PR DESCRIPTION
see bug:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/109756?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
When going into land & buildings page (where data doesn't exist), exception page is is shown (null handling exception)

## Steps to reproduce issue (if relevant)
1. Access land & buildings page from 'land and buildings summary' page where no data already exists - exception page is shown

## Steps to test this PR
1. Access land & buildings page from 'land and buildings summary' page where no data already exists - exception page is NOT shown

## Prerequisites
n/a
