### PR TITLE
108806 access denied page styling

### DIFF
--- a/Dfe.Academies.External.Web/Pages/ApplicationAccessException.cshtml
+++ b/Dfe.Academies.External.Web/Pages/ApplicationAccessException.cshtml
@@ -1,0 +1,25 @@
+﻿@page
+@model Dfe.Academies.External.Web.Pages.ApplicationAccessExceptionModel
+@{
+	ViewData["Title"] = "Oops";
+}
+
+@section BeforeMain
+{
+	<a class="govuk-back-link">Back</a>
+}
+
+<div class="govuk-grid-column-two-thirds">
+	<h1 class="govuk-heading-l">You do not have permission to view this application</h1>
+	<p class="govuk-body">To view and contribute:</p>
+	<ul class="govuk-list govuk-list--bullet">
+		<li>you must have been invited by an existing contributor</li>
+		<li>your email address must match the one entered for you by the person who sent you the invite</li>
+	</ul>
+	<p class="govuk-body">
+		If you have checked these details and are still seeing this message, contact
+        <a class="govuk-link" href="mailto:regionalservices.rg@education.gov.uk">
+            regionalservices.rg@education.gov.uk
+		</a>
+	</p>
+</div>

--- a/Dfe.Academies.External.Web/Pages/ApplicationAccessException.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/ApplicationAccessException.cshtml.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Dfe.Academies.External.Web.Pages
+{
+    public class ApplicationAccessExceptionModel : PageModel
+    {
+		[BindProperty]
+	    public string Message { get; set; } = null!;
+
+	    public void OnGet(string errorMessage)
+        {
+	        Message = errorMessage;
+        }
+    }
+}

--- a/Dfe.Academies.External.Web/Pages/Error.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Error.cshtml
@@ -4,10 +4,10 @@
     ViewData["Title"] = "Error";
 }
 
-<div class="govuk-width-container">
-	<h1 class="text-danger">Sorry, there is a problem with the service</h1>
+<div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
 	<p class="govuk-body">Try again later.</p>
-	<p class="govuk-body text-danger">An error occurred while processing your request.</p>
+	<p class="govuk-body">An error occurred while processing your request.</p>
 
 	@if (Model.ShowRequestId)
 	{

--- a/Dfe.Academies.External.Web/Pages/NotFound.cshtml
+++ b/Dfe.Academies.External.Web/Pages/NotFound.cshtml
@@ -17,7 +17,7 @@
 					If the web address is correct or you selected a link or button,
 					<br>
 					<a class="govuk-link" href="mailto:regionalservices.rg@education.gov.uk">
-						Contact support
+                    regionalservices.rg@education.gov.uk
 					</a>
 				</p>
 			</div>

--- a/Dfe.Academies.External.Web/Pages/NotFound.cshtml
+++ b/Dfe.Academies.External.Web/Pages/NotFound.cshtml
@@ -16,7 +16,7 @@
 				<p class="govuk-body">
 					If the web address is correct or you selected a link or button,
 					<br>
-					<a class="govuk-link" href="mailto:sddservicessupport@education.gov.uk">
+					<a class="govuk-link" href="mailto:regionalservices.rg@education.gov.uk">
 						Contact support
 					</a>
 				</p>


### PR DESCRIPTION
New page and layout as per ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/108806?McasTsid=26110

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
We need to put some code into each page to check whether logged on user has access to the application they are trying to view (they're setup as a contributor). If this check fails, this page should be shown (that code to come later).

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. Browse to https://localhost:44350/application-access-exception to test

## Prerequisites
n/a
