### PR TITLE
105461 wire up add trust page to api

### DIFF
--- a/Dfe.Academies.External.Web.UnitTest/Dfe.Academies.External.Web.UnitTest.csproj
+++ b/Dfe.Academies.External.Web.UnitTest/Dfe.Academies.External.Web.UnitTest.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Models\NewTrustKeyPersonTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="ExampleJsonResponses\createApplicationResponse.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/Dfe.Academies.External.Web.UnitTest/ExampleJsonResponses/getApplicationResponse.json
+++ b/Dfe.Academies.External.Web.UnitTest/ExampleJsonResponses/getApplicationResponse.json
@@ -8,7 +8,7 @@
 			"firstName": "Dan",
 			"lastName": "Good",
 			"emailAddress": "Dan.GOOD@education.gov.uk",
-			"role": "other"
+			"role": "chairOfGovernors"
 		},
 		{
 			"contributorId": 129,
@@ -104,16 +104,8 @@
 				"capitalCarryForwardExplained": "capitalCarryForwardExplained string next Financial Year",
 				"capitalCarryForwardFileLink": "capitalCarryForwardFileLink string"
 			},
-			"loans": [
-				{
-					"loanId": 26,
-					"amount": 500000.00,
-					"purpose": "The purpose of this is to totally revitalise Plymstock School as an even better",
-					"provider": "string",
-					"interestRate": 3.25,
-					"schedule": "string"
-				}
-			],
+			"loans": [],
+			"leases": [],
 			"schoolContributionToTrust": "string",
 			"governingBodyConsentEvidenceDocumentLink": "string",
 			"additionalInformationAdded": false,
@@ -138,7 +130,7 @@
 			"schoolConversionTargetDateExplained": "string",
 			"conversionChangeNamePlanned": true,
 			"proposedNewSchoolName": "string",
-			"applicationJoinTrustReason": "string",
+			"applicationJoinTrustReason": "Because this trust is awesome!",
 			"projectedPupilNumbersYear1": 1000,
 			"projectedPupilNumbersYear2": 1250,
 			"projectedPupilNumbersYear3": 1500,
@@ -147,5 +139,14 @@
 			"schoolSupportGrantFundsPaidTo": "school",
 			"confirmPaySupportGrantToSchool": false
 		}
-	]
+	],
+	"joinTrustDetails": {
+		"id": 2,
+		"ukprn": 1001,
+		"trustName": "Plymouth Community Trust",
+		"changesToTrust": false,
+		"changesToTrustExplained": "Changes To Trust Explanation",
+		"changesToLaGovernance": true,
+		"changesToLaGovernanceExplained": "Governance Governance Governance. Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum "
+	}
 }

--- a/Dfe.Academies.External.Web.UnitTest/Models/ExistingTrustTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Models/ExistingTrustTests.cs
@@ -9,22 +9,51 @@ internal sealed class ExistingTrustTests
 	private static readonly Fixture Fixture = new();
 
 	[Test]
-	public void Constructor___PropertiesSet()
+	public void Constructor___PropertiesSet___MandatoryOnly()
 	{
 		// arrange
+		int applicationId = 99;
 		string trustName = Fixture.Create<string>();
+		int ukprn = Fixture.Create<int>();
 
-		var applicationComponent = new ExistingTrust(trustName)
-		{
-			Id = int.MaxValue
-		};
+		var applicationComponent = new ExistingTrust(applicationId, trustName, ukprn);
 
 		// act
 		// nothing!
 
 		// assert
 		Assert.That(applicationComponent, Is.Not.Null);
-		Assert.That(applicationComponent.Id, Is.EqualTo(int.MaxValue));
+		Assert.That(applicationComponent.ApplicationId, Is.EqualTo(applicationId));
 		Assert.That(applicationComponent.TrustName, Is.EqualTo(trustName));
+		Assert.That(applicationComponent.ukprn, Is.EqualTo(ukprn));
+	}
+
+	[Test]
+	public void Constructor___PropertiesSet___All()
+	{
+		// arrange
+		int applicationId = 99;
+		string trustName = Fixture.Create<string>();
+		int ukprn = Fixture.Create<int>();
+		bool? changesToTrust = Fixture.Create<bool>();
+		string? changesToTrustExplained = null;
+		bool? changesToLaGovernance = Fixture.Create<bool>();
+		string? changesToLaGovernanceExplained = null;
+
+		var applicationComponent = new ExistingTrust(applicationId, trustName, ukprn, 
+						changesToTrust, changesToTrustExplained, changesToLaGovernance, changesToLaGovernanceExplained);
+
+		// act
+		// nothing!
+
+		// assert
+		Assert.That(applicationComponent, Is.Not.Null);
+		Assert.That(applicationComponent.ApplicationId, Is.EqualTo(applicationId));
+		Assert.That(applicationComponent.TrustName, Is.EqualTo(trustName));
+		Assert.That(applicationComponent.ukprn, Is.EqualTo(ukprn));
+		Assert.That(applicationComponent.ChangesToTrust, Is.EqualTo(changesToTrust));
+		Assert.That(applicationComponent.ChangesToTrustExplained, Is.EqualTo(changesToTrustExplained));
+		Assert.That(applicationComponent.ChangesToLaGovernance, Is.EqualTo(changesToLaGovernance));
+		Assert.That(applicationComponent.ChangesToLaGovernanceExplained, Is.EqualTo(changesToLaGovernanceExplained));
 	}
 }

--- a/Dfe.Academies.External.Web/Dfe.Academies.External.Web.csproj
+++ b/Dfe.Academies.External.Web/Dfe.Academies.External.Web.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <Compile Remove="Constants\FieldConstants.cs" />
+    <Compile Remove="Models\NewTrustKeyPerson.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Dfe.Academies.External.Web/Models/ConversionApplication.cs
+++ b/Dfe.Academies.External.Web/Models/ConversionApplication.cs
@@ -34,11 +34,12 @@ public class ConversionApplication
 
 	public int ConversionStatus { get; set; }
 
+	// TODO :- wire up below
 	public NewTrust? FormATrust { get; set; }
 
-	public ExistingTrust? ExistingTrust { get; set; }
+	public ExistingTrust? JoinTrustDetails { get; set; }
 
 	public string TrustName => (ApplicationType == ApplicationTypes.JoinAMat
-		? ExistingTrust?.TrustName
+		? JoinTrustDetails?.TrustName
 		: FormATrust?.ProposedTrustName) ?? string.Empty;
 }

--- a/Dfe.Academies.External.Web/Models/ExistingTrust.cs
+++ b/Dfe.Academies.External.Web/Models/ExistingTrust.cs
@@ -1,20 +1,11 @@
 ﻿namespace Dfe.Academies.External.Web.Models;
 
-public class ExistingTrust
-{
-	public ExistingTrust(string trustName)
-	{
-		TrustName = trustName;
-	}
-
-	public int Id { get; set; }
-
-	/// <summary>
-	/// This would be existing Id from KIM (?)
-	/// </summary>
-	public int TrustId { get; set; }
-
-	public string TrustName { get; set; }
-
-	// TODO:- other questions specific to trust
-}
+public record ExistingTrust(
+	int ApplicationId,
+	string TrustName,
+	int ukprn,
+	bool? ChangesToTrust = null,
+	string? ChangesToTrustExplained = null,
+	bool? ChangesToLaGovernance = null,
+	string? ChangesToLaGovernanceExplained = null
+);

--- a/Dfe.Academies.External.Web/Models/NewTrust.cs
+++ b/Dfe.Academies.External.Web/Models/NewTrust.cs
@@ -5,14 +5,34 @@
 /// </summary>
 public class NewTrust
 {
-	public NewTrust(string proposedTrustName)
+	// TODO MR:- amend this obj = record and to be same as following json
+	// {
+//"applicationId": 0,
+//"formTrustOpeningDate": "2022-10-26T10:30:04.046Z",
+//"formTrustProposedNameOfTrust": "string",
+//"trustApproverName": "string",
+//"trustApproverEmail": "string",
+//"formTrustReasonApprovaltoConvertasSAT": true,
+//"formTrustReasonApprovedPerson": "string",
+//"formTrustReasonForming": "string",
+//"formTrustReasonVision": "string",
+//"formTrustReasonGeoAreas": "string",
+//"formTrustReasonFreedom": "string",
+//"formTrustReasonImproveTeaching": "string",
+//"formTrustPlanForGrowth": "string",
+//"formTrustPlansForNoGrowth": "string",
+//"formTrustGrowthPlansYesNo": true,
+//"formTrustImprovementSupport": "string",
+//"formTrustImprovementStrategy": "string",
+//"formTrustImprovementApprovedSponsor": "string"
+//}
+
+public NewTrust(string proposedTrustName)
 	{
 		ProposedTrustName = proposedTrustName;
 	}
 
 	public int Id { get; set; }
-
-	// TODO MR:- what to do about trust id ????
 
 	public string ProposedTrustName { get; set; }
 
@@ -39,5 +59,5 @@ public class NewTrust
 
 	public string? FormTrustImprovementStrategy { get; set; }
 
-	public List<NewTrustKeyPerson> NewTrustKeyPersons { get; set; } = new();
+	//public List<NewTrustKeyPerson> NewTrustKeyPersons { get; set; } = new();
 }

--- a/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
+++ b/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
@@ -107,17 +107,26 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			// MR:- may need to call GetApplication() first within ConversionApplicationRetrievalService()
 			// to grab current application data
 			// before then patching ConversionApplication returned with data from application object
+			var application = await GetApplication(applicationId);
+
+			if (application.ApplicationId != applicationId)
+			{
+				throw new ArgumentException("Application not found");
+			}
+
+			if (application.ApplicationType != ApplicationTypes.JoinAMat)
+			{
+				throw new ArgumentException("Application not of correct type");
+			}
 
 			//// baseaddress has a backslash at the end to be a valid URI !!!
-			//// https://academies-academisation-api-dev.azurewebsites.net/application/99
-			string apiurl = $"{_httpClient.BaseAddress}application/{applicationId}?api-version=V1";
+			//// https://s184d01-aca-aca-app.nicedesert-a691fec6.westeurope.azurecontainerapps.io/application/99/join-trust
+			string apiurl = $"{_httpClient.BaseAddress}application/{applicationId}/join-trust?api-version=V1";
 
-			// TODO MR:- add to existing / form new route to think about here !
-			// application.Trust = new trust();
+			var trust = new ExistingTrust(applicationId, name, trustUkPrn);
 
-			// TODO API: 
 			// MR:- no response from Academies API - Just an OK
-			// await _resilientRequestProvider.PutAsync(apiurl, application);
+			await _resilientRequestProvider.PutAsync(apiurl, trust);
 		}
 		catch (Exception ex)
 		{


### PR DESCRIPTION
Wire up select trust page up to API as per ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/104124?McasTsid=26110

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
1) Selected trust should be persisted in database
2) selected trust name should show on application overview page

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. go to application overview / press 'add trust' button / search & select trust, press 'Save and continue' trust is persisted
2. select trust name is shown on application overview and  'add trust' button disappears

## Prerequisites
n/a
