### PR TITLE
add currency symbol

### DIFF
--- a/Dfe.Academies.External.Web/Pages/School/Leases.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/Leases.cshtml
@@ -61,7 +61,7 @@
 											    <dt hidden="hidden"></dt>
 											    <dd class="govuk-summary-list__value">
 												    <p class="govuk-label">Purpose: <strong>@Model.LeaseViewModels[i].Purpose</strong></p>
-												    <p class="govuk-label">Amount: <strong>@Model.LeaseViewModels[i].RepaymentAmount</strong></p>
+												    <p class="govuk-label">Amount: <strong>£@Model.LeaseViewModels[i].RepaymentAmount</strong></p>
 												    <a asp-page="/school/LeaseDetails" aria-describedby="component-change" class="govuk-link" asp-route-appId="@Model.ApplicationId" asp-route-urn="@Model.Urn" asp-route-id="@Model.LeaseViewModels[i].Id" asp-route-isEdit="true" asp-route-isDraft="@Model.LeaseViewModels[i].IsDraft">
 												       Change answers
 													</a>


### PR DESCRIPTION
See bug:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/111024?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Currency symbol on leases summary page

## Steps to reproduce issue (if relevant)
1. Go to leases summary page no currency symbol on amount

## Steps to test this PR
1. Go to leases summary page currency symbol on amount

## Prerequisites
n/a