### PR TITLE
AB#109503- Has the school had any grants from Sport England, the Big …

### DIFF
--- a/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/LandAndBuildings.cshtml.cs
@@ -240,6 +240,12 @@ namespace Dfe.Academies.External.Web.Pages.School
 				this.SchoolBuildLandPFISchemeType = null;
 			}
 
+			// if this.SchoolBuildLandGrants == 'no', blank out 'SchoolBuildLandGrantsBodies'
+			if (this.SchoolBuildLandGrants == SelectOption.No)
+			{
+				this.SchoolBuildLandGrantsBodies = null;
+			}
+
 			var landAndBuildingsData = new SchoolLandAndBuildings(
 				this.SchoolBuildLandOwnerExplained,
 				this.SchoolBuildLandWorksPlanned == SelectOption.Yes,


### PR DESCRIPTION
…Lottery Fund, or the Football Federation? - when no selected text/explanation not cleared out

<!--- Link to issue this PR resolves -->
Resolves [#109503](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Apply%20to%20become/Stories/?workitem=109503)

## Type of change
<!--- Tick the appropriate checkbox -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
<!--- Tell us what should happen: -->
<!--- * If a new feature then briefly explain what has been added -->
<!--- * If a bug fix briefly explain what should be happening that isn't -->
There is a question on the Lands and Buildings page 'Has the school had any grants from Sport England, the Big Lottery Fund, or the Football Federation? ' when no is selected any previous explanation that was saved is cleared out.
<!--- * If a breaking change then briefly explain what is changing -->

## Steps to reproduce issue (if relevant)
<!--- Steps to re-create bug before testing, only applies -->
<!--- if PR resolves a bug -->
see bug for steps

## Steps to test this PR
<!--- Suggested steps reviewers need to take to test this PR -->
again steps to test are in the bug

## Prerequisites
<!--- Put any SQL, scripts or software packages that are required to run -->
<!--- this branch on a local copy / in production -->
