### PR TITLE
add privacy link to footer

### DIFF
--- a/Dfe.Academies.External.Web/Pages/Shared/_Footer.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Shared/_Footer.cshtml
@@ -13,6 +13,9 @@
 					<li class="govuk-footer__inline-list-item">
 						<a asp-page="/Terms" class="govuk-footer__link">Terms and Conditions</a>
 					</li>
+                    <li class="govuk-footer__inline-list-item">
+                        <a asp-page="/Privacy" class="govuk-footer__link">Privacy</a>
+                    </li>
 				</ul>
 
 				<svg class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">


### PR DESCRIPTION
see below ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/108927?McasTsid=26110

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
On every page there is a privacy link at the bottom of the page

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. Open application - should have privacy link at the bottom and this should open privacy page
2. Login application - should have privacy link at the bottom and this should open privacy page

## Prerequisites
n/a
