### PR TITLE
Change parameters in `appsettings.json` to use underscores in stead of hyphens

### DIFF
--- a/Dfe.Academies.External.Web.UnitTest/Extensions/StartupExtensionTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Extensions/StartupExtensionTests.cs
@@ -33,8 +33,8 @@ internal sealed class StartupExtensionTests
 		serviceCollection.AddAcademiesApi(new ConfigurationBuilder()
 				   .AddInMemoryCollection(new List<KeyValuePair<string, string>>
 				   {
-						   new("academies-api:endpoint", "1"),
-						   new("academies-api:key", "2")
+						   new("academies_api:endpoint", "1"),
+						   new("academies_api:key", "2")
 				   })
 			.Build());
 
@@ -64,8 +64,8 @@ internal sealed class StartupExtensionTests
 		serviceCollection.AddAcademisationApi(new ConfigurationBuilder()
 			.AddInMemoryCollection(new List<KeyValuePair<string, string>>
 			{
-				new("academisation-api:endpoint", "1"),
-				new("academisation-api:key", "2")
+				new("academisation_api:endpoint", "1"),
+				new("academisation_api:key", "2")
 			})
 			.Build());
 

--- a/Dfe.Academies.External.Web/Extensions/StartupExtensions.cs
+++ b/Dfe.Academies.External.Web/Extensions/StartupExtensions.cs
@@ -14,8 +14,8 @@ public static class StartupExtension
 	/// <exception cref="Exception"></exception>
 	public static void AddAcademiesApi(this IServiceCollection services, IConfiguration configuration)
 	{
-		var academiesApiEndpoint = configuration["academies-api:endpoint"];
-		var academiesApiKey = configuration["academies-api:key"];
+		var academiesApiEndpoint = configuration["academies_api:endpoint"];
+		var academiesApiKey = configuration["academies_api:key"];
 
 		if (string.IsNullOrWhiteSpace(academiesApiEndpoint) || string.IsNullOrWhiteSpace(academiesApiKey))
 			throw new Exception("AddAcademiesApi::missing configuration");
@@ -36,8 +36,8 @@ public static class StartupExtension
 	/// <exception cref="Exception"></exception>
 	public static void AddAcademisationApi(this IServiceCollection services, IConfiguration configuration)
 	{
-		var academisationApiEndpoint = configuration["academisation-api:endpoint"];
-		var academisationApiKey = configuration["academisation-api:key"];
+		var academisationApiEndpoint = configuration["academisation_api:endpoint"];
+		var academisationApiKey = configuration["academisation_api:key"];
 
 		if (string.IsNullOrWhiteSpace(academisationApiEndpoint) || string.IsNullOrWhiteSpace(academisationApiKey))
 			throw new Exception("AddAcademisationApi::missing configuration");

--- a/Dfe.Academies.External.Web/appsettings.Development.json
+++ b/Dfe.Academies.External.Web/appsettings.Development.json
@@ -9,10 +9,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "academies-api": {
+  "academies_api": {
     "endpoint": "https://webapp-t1dv-sip-a2c.azurewebsites.net/"
   },
-  "academisation-api": {
+  "academisation_api": {
     "endpoint": "https://webapp-t1dv-sip-a2c.azurewebsites.net/"
   }
 }

--- a/Dfe.Academies.External.Web/appsettings.json
+++ b/Dfe.Academies.External.Web/appsettings.json
@@ -14,11 +14,11 @@
 		}
 	},
 	"AllowedHosts": "*",
-	"academies-api": {
+	"academies_api": {
 		"endpoint": "This is the endpoint for the Academies API, used for read-only reference data. Override in environment-specific config.",
 		"key": "API Key for the Academies API. Override in environment-specific secrets."
 	},
-	"academisation-api": {
+	"academisation_api": {
 		"endpoint": "This is the endpoint for the academisation API, used for conversion data. Override in environment-specific config.",
 		"key": "API Key for the academisation API. Override in environment-specific secrets."
 	},

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ You will need to configure user secrets to be able to run / contribute to the pr
     "OneloginOpenIdConnectClientId": "",
     "OneloginOpenIdConnectClientSecret": ""
   },
-  "academies-api": {
+  "academies_api": {
     "endpoint": "https://trams-external-api.azurewebsites.net/",
     "key": ""
   },
-  "academisation-api": {
+  "academisation_api": {
     "endpoint": "https://s184d01-aca-aca-app.nicedesert-a691fec6.westeurope.azurecontainerapps.io/",
     "key": ""
   },


### PR DESCRIPTION
* For us to be able to set parameters defined in `appsettings.json` as Environment Variables, the names can't contain hyphens.
* For this to work on running environments, we will need to add the new variable names in before we merge/deploy this