### PR TITLE
Style fix

### DIFF
--- a/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml
+++ b/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml
@@ -121,11 +121,7 @@
     <h2 class="govuk-heading-l">Contributors</h2>
     <p class="govuk-body">You can <a asp-page="AddAContributor" asp-route-appId="@Model.ApplicationId" class="govuk-link">invite other people to help you complete this form</a> or see who has already been invited.</p>
 	<div class="govuk-!-margin-6"></div>
-
-    <partial name="_ApplicationContributorsPartial" model="Model.ExistingContributors" />
-
-    <div class="govuk-!-margin-6"></div>
-
+    
     @if (!Model.UserHasSubmitApplicationRole)
     {
         <p class="govuk-body govuk-radios__conditional">Only the school's chair of governors can submit this application.</p>

--- a/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml.cs
@@ -56,8 +56,6 @@ namespace Dfe.Academies.External.Web.Pages
 		/// </summary>
 		public SchoolComponentsViewModel SchoolComponents { get; private set; } = new();
 
-		public List<ConversionApplicationContributorViewModel> ExistingContributors { get; private set; } = new();
-
 		public ApplicationOverviewModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService,
 										IReferenceDataRetrievalService referenceDataRetrievalService
 		) : base(conversionApplicationRetrievalService, referenceDataRetrievalService)
@@ -176,23 +174,12 @@ namespace Dfe.Academies.External.Web.Pages
 					}
 				}
 
-				// contributors
-				// convert application?.Contributors -> list<ConversionApplicationContributorViewModel>
-				if (conversionApplication.Contributors.Any())
-				{
-					var contributors = conversionApplication.Contributors
-						.Select(e => new ConversionApplicationContributorViewModel(e.FullName, e.Role, e.OtherRoleName))
-						.ToList();
-
-					ExistingContributors = contributors;
-				}
-
-				// TODO MR:- submit button should NOT be available unless ALL school.SchoolApplicationComponents.Status == Completed !!
+				// TODO :- submit button should NOT be available unless ALL school.SchoolApplicationComponents.Status == Completed !!
 				// &&&&&&& application should have a trust ++ trust sections filled in !!
 			}
 		}
 
-		// TODO MR:- what logic drives this !
+		// TODO :- what logic drives this !
 		private Status CalculateApplicationStatus(SchoolApplyingToConvert? school)
 		{
 			if (school != null && school.SchoolApplicationComponents.Any())

--- a/Dfe.Academies.External.Web/Pages/School/Declaration.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/Declaration.cshtml
@@ -38,7 +38,7 @@
 				<ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-6">
 					<li>The governing body has passed a resolution that the school should become an academy.</li>
 					<li>The school will complete a consultation with relevant stakeholders (such as parents, staff, the local communities and others), and consider their equality needs before they sign the funding agreement.</li>
-					<li>The school agrees to the terms set out in the academy <a href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">pre-opening support grant certificate</a>.</li>
+                    <li>The school agrees to the terms set out in the academy <a class="govuk-link" href="https://www.gov.uk/government/publications/academy-support-grant" target="_blank">pre-opening support grant certificate</a>.</li>
 					<li>The school agrees to provide any further information that the Department for Education needs to assess this application.</li>
 					<li>That if any information in this application is false or misleading, this application may be rejected or the academy order may be revoked if it has already been awarded.</li>
 				</ul> 

--- a/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/ApplicationSelectTrust.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/ApplicationSelectTrust.cshtml
@@ -6,7 +6,7 @@
 
 @section BeforeMain
 {
-	<a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back to application overview</a>
+    <a asp-page="../../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back to application overview</a>
 }
 
 <div class="ccms-loader govuk-!-display-none"></div>

--- a/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/TrustConsent.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/TrustConsent.cshtml
@@ -1,6 +1,4 @@
 @page
-@using Dfe.Academies.External.Web.Enums
-@using Dfe.Academies.External.Web.Extensions
 @using Dfe.Academies.External.Web.Helpers
 @using Dfe.Academies.External.Web.ViewModels
 @using Microsoft.AspNetCore.Mvc.TagHelpers

--- a/Dfe.Academies.External.Web/wwwroot/js/academies.trustsearch.js
+++ b/Dfe.Academies.External.Web/wwwroot/js/academies.trustsearch.js
@@ -88,7 +88,7 @@ academies.renderTrustSearchOption = function (selectedValue) {
 	// render partial & set results DIV HTML
 	// unhide selected trust section of screen
 	$.ajax({
-		url: 'trust/ReturnTrustDetailsPartialViewPopulated',
+		url: '../trust/ReturnTrustDetailsPartialViewPopulated',
 		type: 'GET',
 		data: { 'selectedTrust': selectedValue }, // selected value will be in the format 'trust name (UKprn)'
 		success: function (response) {
@@ -112,7 +112,7 @@ function debounceSuggest(query, syncResults) {
 
 academies.GetTrustSearchResults = function (query, syncResults) {
 	$.ajax({
-		url: 'trust/Search',
+		url: '../trust/Search',
 		type: 'GET',
 		data: { 'searchQuery': query },
 		success: function (response) {


### PR DESCRIPTION
See ticket below:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/111918?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
On declaration page,  The 'pre-opening support grant certificate' link was missing css class

## Steps to reproduce issue (if relevant)
1. go to application overview, declaration summary, declaration page 'pre-opening support grant certificate' link missing css class

## Steps to test this PR
1. go to application overview, declaration summary, declaration page 'pre-opening support grant certificate' link NOT missing css class

## Prerequisites
n/a