### PR TITLE
Removed async from upload service because multiple files are not thre…

### DIFF
--- a/Dfe.Academies.External.Web/Services/FileUploadService.cs
+++ b/Dfe.Academies.External.Web/Services/FileUploadService.cs
@@ -39,8 +39,8 @@ public class FileUploadService : IFileUploadService
 		
 		public async Task<string> UploadFile(string entity, string recordId, string recordName, string fieldName, IFormFile file)
 		{
-			await using var memoryStream = new MemoryStream();
-			await file.CopyToAsync(memoryStream);
+			using var memoryStream = new MemoryStream();
+			file.CopyTo(memoryStream);
 
 			var fileName = Path.GetFileName(file.FileName);
 			var newFile = new JObject


### PR DESCRIPTION
…ad safe

<!--- Link to issue this PR resolves -->
Resolves #<1234>

## Type of change
<!--- Tick the appropriate checkbox -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
<!--- Tell us what should happen: -->
<!--- * If a new feature then briefly explain what has been added -->
The application was crashing with multi document uploads because the memory stream file copying isn't thread safe and was causing the streamreader to step out of sync with the file ordering

## Steps to reproduce issue (if relevant)
<!--- Steps to re-create bug before testing, only applies -->
<!--- if PR resolves a bug -->
1. Upload multiple documents on any page with a file upload control
2. See if the 502 error appears
3.
4.

## Steps to test this PR
<!--- Suggested steps reviewers need to take to test this PR -->
1.
2.
3.
4.

## Prerequisites
<!--- Put any SQL, scripts or software packages that are required to run -->
<!--- this branch on a local copy / in production -->
