### PR TITLE
remove text pull right css class on buttons

### DIFF
--- a/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml
+++ b/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml
@@ -29,13 +29,12 @@
 	<h2 class="govuk-heading-m">@Model.SchoolHeaderText</h2>
 
 	<table class="govuk-table">
-@*		<caption class="govuk-table__caption govuk-table__caption--l">@Model.SchoolHeaderText</caption>*@
 		<tbody class="govuk-table__body">
 		@*If no school selected - render button instead*@
 		@if (!Model.SchoolOrSchoolsApplyingToConvert.Any() && Model.ApplicationType != ApplicationTypes.FormAMat)
 		{
 			<tr class="govuk-table__row">
-				<td class="govuk-table__cell govuk-!-text-align-right">
+				<td class="govuk-table__cell">
 					<a asp-page="school/ApplicationSelectSchool" asp-route-appId="@Model.ApplicationId"
 					   class="govuk-button" data-module="govuk-button">Add a school</a>
 				</td>
@@ -65,7 +64,7 @@
 					</tr>
 				}
 				<tr class="govuk-table__row">
-					<td class="govuk-table__cell govuk-!-text-align-right" colspan="2">
+					<td class="govuk-table__cell" colspan="2">
                             <a asp-page="school/ApplicationSelectSchool"
 								asp-route-appId="@Model.ApplicationId"
 						   class="govuk-button" data-module="govuk-button">Add a school</a>
@@ -94,7 +93,7 @@
         <tbody class="govuk-table__body">
             @if (string.IsNullOrWhiteSpace(Model.NameOfTrustToJoin)){
                 <tr class="govuk-table__row">
-                    <td class="govuk-table__cell govuk-!-text-align-right" colspan="2">
+                    <td class="govuk-table__cell" colspan="2">
                         <a asp-page="trust/joinamat/ApplicationSelectTrust" asp-route-appId="@Model.ApplicationId"
 	                       class="govuk-button govuk-button--secondary" data-module="govuk-button">Add a trust</a>
                     </td>
@@ -156,7 +155,6 @@
 @*<div class="govuk-grid-column-one-third">
 	<h2 class="govuk-heading-l">Recent activity</h2>
 	<p class="govuk-body">Changes to the application by all contributors will appear here</p>
-    TODO:- Audit partial listing component
 </div>*@
 
 <partial name="_HiddenFields"/>


### PR DESCRIPTION
See ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/112258?McasTsid=26110

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Everything done on ticket, bar the buttons (add school / add trust) should be left aligned

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. go to application overview page with no school or trust and add school / add trust buttons should be aligned left
2.
3.
4.

## Prerequisites
n/a
