### PR TITLE
amend finance summary section status to use new flags (leases & loans)

### DIFF
--- a/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml.cs
@@ -187,17 +187,24 @@ namespace Dfe.Academies.External.Web.Pages
 							}).ToList()
 					};
 
-					// TODO:- need to remove declaration if NOT all sections have been completed!
-
 					SchoolComponents = componentsVm;
 				}
 
-				// TODO :- submit button should NOT be available unless ALL school.SchoolApplicationComponents.Status == Completed !!
+				// TODO:- need to remove 'Only the school's chair of governors can submit this application' for
+				// non-chair user if declaration not filled in?? see ticket (https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/112259)
+				// TODO:- need seperate flag against conversionApplication?
+
+				// TODO :- submit button should NOT be available unless ALL school.SchoolApplicationComponents.Status == Completed !! see ticket (https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/112260)
 				// &&&&&&& application should have a trust ++ trust sections filled in !!
 			}
 		}
 
-		// TODO :- what logic drives this !
+		/// <summary>
+		/// calculate overall application status based on whether all sections have been completed
+		/// INCLUDING declaration i.e. submit button is visible!!
+		/// </summary>
+		/// <param name="school"></param>
+		/// <returns></returns>
 		private Status CalculateApplicationStatus(SchoolApplyingToConvert? school)
 		{
 			if (school != null && school.SchoolApplicationComponents.Any())
@@ -211,6 +218,8 @@ namespace Dfe.Academies.External.Web.Pages
 					return Status.InProgress;
 				}
 			}
+
+			// TODO:- will also need to check trust status flag which is separate from above
 
 			return Status.NotStarted;
 		}

--- a/Dfe.Academies.External.Web/Pages/School/FinancesReview.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/FinancesReview.cshtml.cs
@@ -229,13 +229,15 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		private FinancesReviewHeadingViewModel PopulateLoansHeading(SchoolApplyingToConvert selectedSchool)
 		{
+			// work out whether section started or not !
+			//var isStarted = loansHeading.Status != SchoolConversionComponentStatus.NotStarted;
+			bool? isStarted = selectedSchool.HasLoans;
 			
 			FinancesReviewHeadingViewModel loansHeading = new(FinancesReviewHeadingViewModel.HeadingLoans,
 				"/school/Loans")
 			{
-				Status = selectedSchool.Loans != null ? SchoolConversionComponentStatus.Complete : SchoolConversionComponentStatus.NotStarted
+				Status = isStarted.HasValue ? SchoolConversionComponentStatus.Complete : SchoolConversionComponentStatus.NotStarted
 			};
-			var isStarted = loansHeading.Status != SchoolConversionComponentStatus.NotStarted;
 			
 			var subQuestionAndAnswers = new List<SchoolQuestionAndAnswerViewModel>();
 				
@@ -254,7 +256,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			var financesReviewHeading = new FinancesReviewSectionViewModel(
 					FinancesReviewSectionViewModel.ExistingLoans,
-					isStarted ? selectedSchool.Loans.Any() ? "Yes" : "No" : QuestionAndAnswerConstants.NoInfoAnswer);
+					selectedSchool.Loans.Any() ? "Yes" : "No");
 
 			if (selectedSchool.Loans.Any())
 				financesReviewHeading.SubQuestionAndAnswers = subQuestionAndAnswers;
@@ -266,12 +268,15 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		private FinancesReviewHeadingViewModel PopulateLeasesHeading(SchoolApplyingToConvert selectedSchool)
 		{
+			// work out whether section started or not !
+			//var isStarted = leasesHeading.Status != SchoolConversionComponentStatus.NotStarted;
+			bool? isStarted = selectedSchool.HasLeases;
+
 			FinancesReviewHeadingViewModel leasesHeading = new(FinancesReviewHeadingViewModel.HeadingLeases,
 				"/school/Leases")
 			{
-				Status = selectedSchool.Leases != null ? SchoolConversionComponentStatus.Complete : SchoolConversionComponentStatus.NotStarted
+				Status = isStarted.HasValue ? SchoolConversionComponentStatus.Complete : SchoolConversionComponentStatus.NotStarted
 			};
-			var isStarted = leasesHeading.Status != SchoolConversionComponentStatus.NotStarted;
 			
 			var subQuestionAndAnswers = new List<SchoolQuestionAndAnswerViewModel>();
 				
@@ -292,7 +297,7 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 			var financesReviewHeading = new FinancesReviewSectionViewModel(
 				FinancesReviewSectionViewModel.ExistingLeases,
-				isStarted ? selectedSchool.Leases.Any() ? "Yes" : "No" : QuestionAndAnswerConstants.NoInfoAnswer);
+				selectedSchool.Leases.Any() ? "Yes" : "No");
 			
 			if (selectedSchool.Leases.Any())
 				financesReviewHeading.SubQuestionAndAnswers = subQuestionAndAnswers;

--- a/Dfe.Academies.External.Web/Services/ConversionApplicationRetrievalService.cs
+++ b/Dfe.Academies.External.Web/Services/ConversionApplicationRetrievalService.cs
@@ -192,42 +192,61 @@ public sealed class ConversionApplicationRetrievalService : BaseService, IConver
 	}
 
 	/// <summary>
-	/// About the conversion = 5 sections - so could return 'In Progress'
+	/// About the conversion = 4 sections - so could return 'In Progress' or Completed or NotStarted
+	/// Same logic in here as summary page. Should we re-factor?
 	/// </summary>
 	/// <param name="selectedSchool"></param>
 	/// <returns></returns>
 	private Status CalculateAboutTheConversionSectionStatus(SchoolApplyingToConvert? selectedSchool)
 	{
-		// TODO MR:- agree logic
+		// need 4 bools to represent each sub-section. completed = yes/no
+		// 1) SchoolMainContacts = !string.IsNullOrEmpty(selectedSchool.SchoolConversionContactHeadName)
+		// 2) ApplicationConversionTargetDate = selectedSchool.SchoolConversionTargetDateSpecified.HasValue
+		// 3) ApplicationJoinTrustReasons = !string.IsNullOrWhiteSpace(selectedSchool.ApplicationJoinTrustReason)
+		// 4) ApplicationChangeSchoolName = selectedSchool.ConversionChangeNamePlanned.HasValue
+
+		// TODO :- agree logic
 		return Status.InProgress;
 	}
 
 	/// <summary>
-	/// Further information = 2 sections(?) - so could return 'In Progress'
+	/// Will only return Completed or NotStarted as only one logic check !
+	/// Same logic in here as summary page. Should we re-factor?
 	/// </summary>
 	/// <param name="selectedSchool"></param>
 	/// <returns></returns>
 	private Status CalculateFurtherInformationSectionStatus(SchoolApplyingToConvert? selectedSchool)
 	{
-		// TODO MR:- agree logic
+		// one LARGE form in v1.5. So can just use below logic:-
+		// var sectionStarted = !string.IsNullOrEmpty(selectedSchool.TrustBenefitDetails)
+
+		// TODO
 		return Status.InProgress;
 	}
 
 	/// <summary>
-	/// Finance = 6 sections - so could return 'In Progress'
+	/// Finance = 6 sections - so could return 'In Progress' or Completed or NotStarted
+	/// Same logic in here as summary page. Should we re-factor?
 	/// </summary>
 	/// <param name="selectedSchool"></param>
 	/// <returns></returns>
 	private Status CalculateFinanceSectionStatus(SchoolApplyingToConvert? selectedSchool)
 	{
-		//need 6 bools to represent each sub-section. completed = yes/no
+		// need 6 bools to represent each sub-section. completed = yes/no
+		// 1) PreviousFinancialYear = selectedSchool.previousFinancialYear.FinancialYearEndDate.HasValue
+		// 2) CurrentFinancialYear = selectedSchool.currentFinancialYear.FinancialYearEndDate.HasValue
+		// 3) NextFinancialYear = selectedSchool.nextFinancialYear.FinancialYearEndDate.HasValue
+		// 4) loans = selectedSchool.HasLoans
+		// 5) leases = selectedSchool.HasLeases
+		// 6) FinancialInvestigations = selectedSchool.FinanceOngoingInvestigations.HasValue
 
-		// TODO MR:- agree logic
+		// TODO :- agree logic
 		return Status.InProgress;
 	}
 
 	/// <summary>
-	/// Same logic in here as future pupil numbers summary. Should we re-factor?
+	/// Will only return Completed or NotStarted as only one logic check !
+	/// Same logic in here as future pupil numbers summary page. Should we re-factor?
 	/// </summary>
 	/// <param name="selectedSchool"></param>
 	/// <returns></returns>
@@ -239,7 +258,8 @@ public sealed class ConversionApplicationRetrievalService : BaseService, IConver
 	}
 
 	/// <summary>
-	/// Same logic in here as Land and buildings summary. Should we re-factor?
+	/// Will only return Completed or NotStarted as only one logic check !
+	/// Same logic in here as Land and buildings summary page. Should we re-factor?
 	/// </summary>
 	/// <param name="selectedSchool"></param>
 	/// <returns></returns>
@@ -251,7 +271,8 @@ public sealed class ConversionApplicationRetrievalService : BaseService, IConver
 	}
 
 	/// <summary>
-	/// Same logic in here as consultation summary. Should we re-factor?
+	/// Will only return Completed or NotStarted as only one logic check !
+	/// Same logic in here as consultation summary page. Should we re-factor?
 	/// </summary>
 	/// <param name="selectedSchool"></param>
 	/// <returns></returns>
@@ -263,7 +284,8 @@ public sealed class ConversionApplicationRetrievalService : BaseService, IConver
 	}
 
 	/// <summary>
-	/// Same logic in here as Pre-opening support grant summary. Should we re-factor?
+	/// Will only return Completed or NotStarted as only one logic check !
+	/// Same logic in here as Pre-opening support grant summary page. Should we re-factor?
 	/// </summary>
 	/// <param name="selectedSchool"></param>
 	/// <returns></returns>
@@ -275,7 +297,8 @@ public sealed class ConversionApplicationRetrievalService : BaseService, IConver
 	}
 
 	/// <summary>
-	/// Same logic in here as declaration summary. Should we re-factor?
+	/// Will only return Completed or NotStarted as only one logic check !
+	/// Same logic in here as declaration summary page. Should we re-factor?
 	/// </summary>
 	/// <param name="selectedSchool"></param>
 	/// <returns></returns>


### PR DESCRIPTION
tickets already resolved so no ticket

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
<!--- Tell us what should happen: -->
<!--- * If a new feature then briefly explain what has been added -->
<!--- * If a bug fix briefly explain what should be happening that isn't -->
<!--- * If a breaking change then briefly explain what is changing -->

## Steps to reproduce issue (if relevant)
1. leases marked as no, without any leases - 'not started' button shows
2. loans marked as no, without any leases - 'not started' button shows

## Steps to test this PR
1. go to finance summary - leases marked as no - heading status = 'NotStarted'
2. go to finance summary - leases marked as yes - heading status = 'Complete'
3. go to finance summary - loans marked as no - heading status = 'NotStarted'
4. go to finance summary - loans marked as yes - heading status = 'Complete'

## Prerequisites
n/a
