### PR TITLE
112106 email contributor fixes

### DIFF
--- a/Dfe.Academies.External.Web/Pages/AddAContributor.cshtml
+++ b/Dfe.Academies.External.Web/Pages/AddAContributor.cshtml
@@ -20,12 +20,12 @@
 	    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
 		    <div class="govuk-notification-banner__header">
 			    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-				    Invitation Email sent
+				    Contributor added
 			    </h2>
 		    </div>
 		    <div class="govuk-notification-banner__content">
 			    <h3 class="govuk-notification-banner__heading">
-				    The new contributors name will now appear here and in the application overview and that person can now access this application.
+                    @Model.Name has been sent an invitation to help with this application.
 			    </h3>
 		    </div>
 	    </div>

--- a/Dfe.Academies.External.Web/Pages/AddAContributor.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/AddAContributor.cshtml.cs
@@ -120,9 +120,8 @@ namespace Dfe.Academies.External.Web.Pages
 			string lastName = User.FindFirst(ClaimTypes.Surname)?.Value ?? "";
 			string invitingUserName = $"{firstName} {lastName}";
 
-			// TODO:- school name?
 			await _contributorEmailSenderService.SendInvitationToContributor(draftConversionApplication.ApplicationType, ContributorRole,
-				Name!, EmailAddress!, "",
+				Name!, EmailAddress!, ApplicationSchoolName(draftConversionApplication),
 				invitingUserName);
 
 			// update temp store for next step
@@ -134,6 +133,7 @@ namespace Dfe.Academies.External.Web.Pages
 
 			// MR:- need to call below otherwise will lose ExistingContributors()
 			PopulateUiModel(draftConversionApplication);
+			Name = Name;
 			return Page();
 		}
 
@@ -214,6 +214,29 @@ namespace Dfe.Academies.External.Web.Pages
 			}
 			
 			// this form won't be used as an update. Only add, so hence, so no VM property binding
+		}
+
+		private string ApplicationSchoolName(ConversionApplication? conversionApplication)
+		{
+			if (conversionApplication != null)
+			{
+				if (conversionApplication.ApplicationType == ApplicationTypes.JoinAMat)
+				{
+					var school = conversionApplication.Schools.FirstOrDefault();
+
+					if (school != null)
+					{
+						return school.SchoolName;
+					}
+				}
+				else // FAM
+				{
+					// TODO: user will have to select a school !!!!
+					return string.Empty;
+				}
+			}
+
+			return string.Empty;
 		}
 	}
 }


### PR DESCRIPTION
See below tickets:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/112106?McasTsid=26110
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/112108?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Amend banner text (after save)
Amend email substitutions - school name not being sent down the wire

## Steps to reproduce issue (if relevant)
1. Add a contributor (using ONLY configured email address on gov uk notify). Press save
2. When you receive email, school name DOES NOT show

## Steps to test this PR
1. Add a contributor (using ONLY configured email address on gov uk notify). Press save
2. Banner text should be same as ticket
3. When you receive email, school name should now show

## Prerequisites
n/a
