### PR TITLE
104661 minor changes to the trust fixes

### DIFF
--- a/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/ApplicationSchoolChangesToATrust.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/ApplicationSchoolChangesToATrust.cshtml
@@ -19,58 +19,56 @@
         <partial name="_HiddenFields" />
 
         <div class="govuk-grid-column-two-thirds">
-            <span class="govuk-caption-l">@Model.SelectedTrustName (step 2 of 3)</span>
-            <h1 class="govuk-heading-l">
-                Changes to the trust
-            </h1>
+	        <h1 class="govuk-heading-l">
+	            <span class="govuk-caption-l">@Model.SelectedTrustName (step 2 of 3)</span>
+	            Changes to the trust
+	        </h1>
 
-            <div class="@(!ViewData.ModelState.IsValid ? "govuk-form-group--error" : "")">
-                <fieldset class="govuk-fieldset">
-                    <div class="govuk-form-group govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-                        <legend id="role-hint" class="govuk-fieldset__legend govuk-!-font-weight-bold">
-                            Will there be changes to the governance of the trust due to the school joining?
-                        </legend>
-                        <label for="trustChangeReason" class="govuk-label">For example, changes to the trustees or their roles</label>
-                        <div class="govuk-form-group">
-                        @foreach (var trustChange in Enum.GetValues(typeof(TrustChange)).OfType<TrustChange>())
-                        {
-                            <div class="govuk-radios__item">
-                                <input type="radio"
-                                   asp-for="TrustChange"
-                                   value="@Convert.ToInt32(trustChange)"
-                                   id="revenueRevenueType@(trustChange)"
-                                   class="govuk-radios__input"
-                                   data-aria-controls="trustChange-@(trustChange.ToString().ToLower())"
-                                   checked="@(trustChange.Equals(Model.TrustChange))"
-                                   aria-expanded="False" />
-                                <label for="revenueType@(trustChange)" class="govuk-label govuk-radios__label">
-                                    @trustChange.GetDescription()
-                                </label>
-                            </div>
+	        <div class="@(!ViewData.ModelState.IsValid ? "govuk-form-group--error" : "")">
+		        <fieldset class="govuk-fieldset">
+			        <div class="govuk-form-group govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+				        <legend id="role-hint" class="govuk-fieldset__legend govuk-!-font-weight-bold">
+					        Will there be changes to the governance of the trust due to the school joining?
+				        </legend>
+						<label for="TrustChange" class="govuk-caption-l">For example, changes to the trustees or their roles</label>
+				        <div class="govuk-form-group">
+					        @foreach (var trustChange in Enum.GetValues(typeof(TrustChange)).OfType<TrustChange>())
+					        {
+						        <div class="govuk-radios__item">
+							        <input type="radio"
+							               asp-for="TrustChange"
+							               value="@Convert.ToInt32(trustChange)"
+							               id="revenueRevenueType@(trustChange)"
+							               class="govuk-radios__input"
+							               data-aria-controls="trustChange-@(trustChange.ToString().ToLower())"
+							               checked="@(trustChange.Equals(Model.TrustChange))"
+							               aria-expanded="False"/>
+							        <label for="revenueType@(trustChange)" class="govuk-label govuk-radios__label">
+								        @trustChange.GetDescription()
+							        </label>
+						        </div>
 
-                            @if (trustChange == TrustChange.Yes)
-                            {
-                                <div class="@(Model.TrustChangeExplainedError ? "govuk-form-group--error" : "govuk-radios__conditional")
-							@(Model.TrustChange != TrustChange.Yes ? "govuk-radios__conditional--hidden" : "")"
-                             id="trustChange-yes" aria-expanded="false">
-                                    <a href="#TrustChangeExplainedNotEntered"
-                               class="@(Model.TrustChangeExplainedError ? "govuk-error-message" : "govuk-visually-hidden")">
-                                        You must enter the details of the changes to the trust
-                                    </a>
-                                    <span class="govuk-hint">
-                                        What are the changes
-                                    </span>
-                                    <textarea asp-for="TrustChangeExplained" id="PFYRevenueStatusExplained"
+						        @if (trustChange == TrustChange.Yes)
+						        {
+							        <div class="@(Model.TrustChangeExplainedError ? "govuk-form-group--error" : "govuk-radios__conditional")
+										@(Model.TrustChange != TrustChange.Yes ? "govuk-radios__conditional--hidden" : "")"
+							             id="trustChange-yes" aria-expanded="false">
+								        <a href="#TrustChangeExplainedNotEntered"
+								           class="@(Model.TrustChangeExplainedError ? "govuk-error-message" : "govuk-visually-hidden")">
+									        You must enter the details of the changes to the trust
+								        </a>
+										<label for="TrustChangeExplained" class="govuk-label">What are the changes?</label>
+								        <textarea asp-for="TrustChangeExplained" id="PFYRevenueStatusExplained"
                                       class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
-                                </div>
-                            }
-                        }
-                    </div>
-                </div>
-            </fieldset>
+							        </div>
+						        }
+					        }
+				        </div>
+			        </div>
+		        </fieldset>
+	        </div>
+
+	        <input type="submit" value="Save and continue" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8"/>
+
         </div>
-
-        <input type="submit" value="Save and continue" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8" />
-
-    </div>
 </form>

--- a/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/ApplicationSchoolChangesToATrust.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/ApplicationSchoolChangesToATrust.cshtml.cs
@@ -35,16 +35,18 @@ namespace Dfe.Academies.External.Web.Pages.Trust.JoinAMat
 			}
 		}
 
+		///<inheritdoc/>
 		public override void PopulateValidationMessages()
 		{
 			PopulateViewDataErrorsWithModelStateErrors();
 		}
 
+		///<inheritdoc/>
 		public override bool RunUiValidation()
 		{
 			if (!TrustChange.HasValue || TrustChange.Value == Enums.TrustChange.Yes && string.IsNullOrWhiteSpace(TrustChangeExplained))
 			{
-				ModelState.AddModelError("TrustChangeExplainedNotEntered", "You must provide details");
+				ModelState.AddModelError("TrustChangeExplainedNotEntered", "You must select an option");
 				PopulateValidationMessages();
 				return false;
 			}
@@ -52,8 +54,7 @@ namespace Dfe.Academies.External.Web.Pages.Trust.JoinAMat
 			return true;
 		}
 
-
-
+		///<inheritdoc/>
 		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
 		{
 			return new();
@@ -98,6 +99,7 @@ namespace Dfe.Academies.External.Web.Pages.Trust.JoinAMat
 			return RedirectToPage(NextStepPage, new { appId = ApplicationId, urn = Urn });
 		}
 
+		///<inheritdoc/>
 		public override void PopulateUiModel(SchoolApplyingToConvert selectedSchool)
 		{
 		}

--- a/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/ApplicationSchoolChangesToATrust.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/ApplicationSchoolChangesToATrust.cshtml.cs
@@ -9,6 +9,8 @@ using Dfe.Academies.External.Web.Pages.Base;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Notify.Models;
+using Dfe.Academies.External.Web.Attributes;
+using static GovUk.Frontend.AspNetCore.ComponentDefaults;
 
 namespace Dfe.Academies.External.Web.Pages.Trust.JoinAMat
 {
@@ -44,9 +46,16 @@ namespace Dfe.Academies.External.Web.Pages.Trust.JoinAMat
 		///<inheritdoc/>
 		public override bool RunUiValidation()
 		{
-			if (!TrustChange.HasValue || TrustChange.Value == Enums.TrustChange.Yes && string.IsNullOrWhiteSpace(TrustChangeExplained))
+			if (!TrustChange.HasValue)
 			{
-				ModelState.AddModelError("TrustChangeExplainedNotEntered", "You must select an option");
+				ModelState.AddModelError("TrustChangeExplainedNotSelected", "You must select an option");
+				PopulateValidationMessages();
+				return false;
+			}
+
+			if (TrustChange.HasValue && TrustChange.Value == Enums.TrustChange.Yes && string.IsNullOrWhiteSpace(TrustChangeExplained))
+			{
+				ModelState.AddModelError("TrustChangeExplainedNotEntered", "You must provide details");
 				PopulateValidationMessages();
 				return false;
 			}


### PR DESCRIPTION
See ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/104661?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
a) amended css class changed  to 'govuk-caption-l' same as other parts of the system
b) '?' added and css class changed to 'govuk-label' same as other parts of the system where optional textboxes are shown
scenario 8) validation text changed

## Steps to reproduce issue (if relevant)
1. go to application overview, 'trust details', 'change your answers', step 2, 'for example ..' - wrong font
2. go to application overview, 'trust details', 'change your answers', step 2, 'what are the changes ...' missing '?'
3. validation warning text not as per UAC

## Steps to test this PR
1. go to application overview, 'trust details', 'change your answers', step 2, 'for example ..' - rightfont
2. go to application overview, 'trust details', 'change your answers', step 2, 'what are the changes ...' has'?'
3. validation warning text per UAC

## Prerequisites
n/a
