### PR TITLE
invite a contributor banner title & content mods

### DIFF
--- a/Dfe.Academies.External.Web/Pages/AddAContributor.cshtml
+++ b/Dfe.Academies.External.Web/Pages/AddAContributor.cshtml
@@ -20,13 +20,14 @@
 	    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
 		    <div class="govuk-notification-banner__header">
 			    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-				    Contributor added
+				    Success
 			    </h2>
 		    </div>
 		    <div class="govuk-notification-banner__content">
 			    <h3 class="govuk-notification-banner__heading">
-                    @Model.Name has been sent an invitation to help with this application.
+				    Contributor added
 			    </h3>
+                <p>@Model.Name has been sent an invitation to help with this application.</p>
 		    </div>
 	    </div>
     }


### PR DESCRIPTION
See below:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/112106?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
A) It has appeared to fail as where the Design says "Success", the actual page says "Contributor added".
B) The message on the design under "Success" states "Contributor added" as a heading where as the actual page says "Abi Adebanjo has been sent an invitation to help with this application."
C) The design also has this above text underlined in a smaller font.

## Steps to reproduce issue (if relevant)
1. go to app overview, invite a contributor, success banner doesn't look like attached screenshot

## Steps to test this PR
1. go to app overview, invite a contributor, success banner doesn't look like attached screenshot

## Prerequisites
n/a