### PR TITLE
104662 styling fixes

### DIFF
--- a/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/ApplicationSchoolChangesToATrust.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/ApplicationSchoolChangesToATrust.cshtml
@@ -30,7 +30,10 @@
 				        <legend id="role-hint" class="govuk-fieldset__legend govuk-!-font-weight-bold">
 					        Will there be changes to the governance of the trust due to the school joining?
 				        </legend>
-						<label for="TrustChange" class="govuk-caption-l">For example, changes to the trustees or their roles</label>
+				        <label for="TrustChange" class="govuk-caption-l">
+					        For example, changes to the trustees or their roles
+				        </label>
+				        <div class="govuk-!-margin-6"></div>
 				        <div class="govuk-form-group">
 					        @foreach (var trustChange in Enum.GetValues(typeof(TrustChange)).OfType<TrustChange>())
 					        {

--- a/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/ApplicationSchoolLocalGovernanceArrangements.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/ApplicationSchoolLocalGovernanceArrangements.cshtml
@@ -19,58 +19,61 @@
         <partial name="_HiddenFields" />
 
         <div class="govuk-grid-column-two-thirds">
-            <span class="govuk-caption-l">@Model.SelectedTrustName (step 3 of 3)</span>
-            <h1 class="govuk-heading-l">
-                Local governance arrangements
-            </h1>
+	        <h1 class="govuk-heading-l">
+		        <span class="govuk-caption-l">@Model.SelectedTrustName (step 2 of 3)</span>
+	            Local governance arrangements
+	        </h1>
 
-            <div class="@(!ViewData.ModelState.IsValid ? "govuk-form-group--error" : "")">
-                <fieldset class="govuk-fieldset">
-                    <div class="govuk-form-group govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-                        <legend id="role-hint" class="govuk-fieldset__legend govuk-!-font-weight-bold">
-	                        Will there be any changes at a local level due to this school joining?
-                        </legend>
-                        <label for="laGovernanceReason" class="govuk-label">For example, setting up a local sub-regional hub or changes to any schemes of delegation.</label>
-                        <div class="govuk-form-group">
-                        @foreach (var changesToLaGovernanceOption in Enum.GetValues<SelectOption>().OrderByDescending(x => x == SelectOption.Yes))
-                        {
-                            <div class="govuk-radios__item">
-                                <input type="radio"
-                                   asp-for="ChangesToLaGovernanceOption"
-                                   value="@Convert.ToInt32(changesToLaGovernanceOption)"
-                                   id="changesToLaGovernance@(changesToLaGovernanceOption)"
-                                   class="govuk-radios__input"
-                                   data-aria-controls="changesToLaGovernance-@(changesToLaGovernanceOption.ToString().ToLower())"
-                                   checked="@(changesToLaGovernanceOption.Equals(Model.ChangesToLaGovernanceOption))"
-                                   aria-expanded="False" />
-                                <label for="changesToLaGovernance@(changesToLaGovernanceOption)" class="govuk-label govuk-radios__label">
-                                    @changesToLaGovernanceOption.GetDescription()
-                                </label>
-                            </div>
+	        <div class="@(!ViewData.ModelState.IsValid ? "govuk-form-group--error" : "")">
+		        <fieldset class="govuk-fieldset">
+			        <div class="govuk-form-group govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+				        <legend id="role-hint" class="govuk-fieldset__legend govuk-!-font-weight-bold">
+					        Will there be any changes at a local level due to this school joining?
+				        </legend>
+				        <label for="ChangesToLaGovernanceOption" class="govuk-caption-l">
+					        For example, setting up a local sub-regional hub or changes to any schemes of delegation.
+				        </label>
+				        <div class="govuk-!-margin-6"></div>
+				        <div class="govuk-form-group">
+					        @foreach (var changesToLaGovernanceOption in Enum.GetValues<SelectOption>().OrderByDescending(x => x == SelectOption.Yes))
+					        {
+						        <div class="govuk-radios__item">
+							        <input type="radio"
+							               asp-for="ChangesToLaGovernanceOption"
+							               value="@Convert.ToInt32(changesToLaGovernanceOption)"
+							               id="changesToLaGovernance@(changesToLaGovernanceOption)"
+							               class="govuk-radios__input"
+							               data-aria-controls="changesToLaGovernance-@(changesToLaGovernanceOption.ToString().ToLower())"
+							               checked="@(changesToLaGovernanceOption.Equals(Model.ChangesToLaGovernanceOption))"
+							               aria-expanded="False"/>
+							        <label for="changesToLaGovernance@(changesToLaGovernanceOption)" class="govuk-label govuk-radios__label">
+								        @changesToLaGovernanceOption.GetDescription()
+							        </label>
+						        </div>
 
-                            @if (changesToLaGovernanceOption == SelectOption.Yes)
-                            {
-                                <div class="@(Model.ChangesToLaGovernanceDetailsError ? "govuk-form-group--error" : "govuk-radios__conditional")
-							@(Model.ChangesToLaGovernanceOption != SelectOption.Yes ? "govuk-radios__conditional--hidden" : "")"
-                             id="changesToLaGovernance-yes" aria-expanded="false">
-                                    <a href="#ChangesToLaGovernanceExplainedNotEntered"
-                               class="@(Model.ChangesToLaGovernanceDetailsError ? "govuk-error-message" : "govuk-visually-hidden")">
-                                        You must enter the details of the changes to the governance
-                                    </a>
-                                    <span class="govuk-hint">
-                                        What are the changes
-                                    </span>
-                                    <textarea asp-for="ChangesToLaGovernanceExplained" id="ChangesToLaGovernanceExplained"
-                                      class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
-                                </div>
-                            }
-                        }
-                    </div>
-                </div>
-            </fieldset>
+						        @if (changesToLaGovernanceOption == SelectOption.Yes)
+						        {
+							        <div class="@(Model.ChangesToLaGovernanceDetailsError ? "govuk-form-group--error" : "govuk-radios__conditional")
+										@(Model.ChangesToLaGovernanceOption != SelectOption.Yes ? "govuk-radios__conditional--hidden" : "")"
+							             id="changesToLaGovernance-yes" aria-expanded="false">
+								        <a href="#ChangesToLaGovernanceExplainedNotEntered"
+								           class="@(Model.ChangesToLaGovernanceDetailsError ? "govuk-error-message" : "govuk-visually-hidden")">
+									        You must enter the details of the changes to the governance
+								        </a>
+								        <label for="ChangesToLaGovernanceExplained" class="govuk-label">
+									        What are the changes and how do they fit into the current lines of accountability in the trust?
+								        </label>
+								        <textarea asp-for="ChangesToLaGovernanceExplained" id="ChangesToLaGovernanceExplained"
+											class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
+							        </div>
+						        }
+					        }
+				        </div>
+			        </div>
+		        </fieldset>
+	        </div>
+
+	        <input type="submit" value="Save and continue" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8"/>
+
         </div>
-
-        <input type="submit" value="Save and continue" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8" />
-
-    </div>
 </form>


### PR DESCRIPTION
See comments on below ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/104662?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
1 A) "For example, setting up a local sub-regional hub or changes to any schemes of delegation." text should ideally be grey
B) Text under selected "Yes" option should read "What are the changes and how do they fit into the current lines of accountability in the trust?" and should be in black
C) Yes radio button option looks very close to the text above it compared to the design.  Perhaps a couple more line-breaks should be added here

## Steps to reproduce issue (if relevant)
1. go to application overview, trust details, change answers, step 3 of 3 page has 3 styling issues (as above)

## Steps to test this PR
1. go to application overview, trust details, change answers, step 3 of 3 page no longer has 3 styling issues (as above)

## Prerequisites
n/a
