### PR TITLE
new trust serilization bug fix

### DIFF
--- a/Dfe.Academies.External.Web/Models/NewTrust.cs
+++ b/Dfe.Academies.External.Web/Models/NewTrust.cs
@@ -3,8 +3,15 @@
 /// <summary>
 /// Object to represent data capture required when Forming a new MAT / FormNewSingleAcademyTrust
 /// </summary>
-public class NewTrust
+public sealed class NewTrust
 {
+	/// <summary>
+	/// need empty ctor for JSON de-serialization !!
+	/// </summary>
+	public NewTrust()
+	{
+	}
+
 	public NewTrust(int applicationId, string proposedTrustName)
 	{
 		ApplicationId = applicationId;


### PR DESCRIPTION
n/a

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
If you try and go into a FAM application on application overview code blow up with following:-
Dfe.Academies.External.Web.Services.ConversionApplicationRetrievalService: Error: ConversionApplicationRetrievalService::GetApplication::Exception - Each parameter in the deserialization constructor on type 'Dfe.Academies.External.Web.Models.NewTrust' must bind to an object property or field on deserialization. 
Each parameter name must match with a property or field on the object. The match can be case-insensitive.

## Steps to reproduce issue (if relevant)
1. Go into a FAM application from your applications, you can't

## Steps to test this PR
1. Go into a FAM application from your applications, you can

## Prerequisites
n/a
