### PR TITLE
remove a contributor - can remove self

### DIFF
--- a/Dfe.Academies.External.Web.UnitTest/ViewModels/ConversionApplicationContributorViewModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/ViewModels/ConversionApplicationContributorViewModelTests.cs
@@ -18,8 +18,10 @@ internal sealed class ConversionApplicationContributorViewModelTests
 		string fullname = Fixture.Create<string>();
 		SchoolRoles schoolRole = SchoolRoles.Other;
 		string otherRoleNotListed = Fixture.Create<string>();
+		string emailAddress = Fixture.Create<string>();
 
-		var contributor = new ConversionApplicationContributorViewModel(contributorId, applicationId, fullname, schoolRole, otherRoleNotListed);
+		var contributor = new ConversionApplicationContributorViewModel(contributorId, applicationId, 
+			fullname, schoolRole, otherRoleNotListed, emailAddress);
 
 		// act
 		// nothing!
@@ -30,6 +32,7 @@ internal sealed class ConversionApplicationContributorViewModelTests
 		Assert.That(contributor.ApplicationId, Is.EqualTo(applicationId));
 		Assert.That(contributor.FullName, Is.EqualTo(fullname));
 		Assert.That(contributor.RoleName, Is.EqualTo($"{otherRoleNotListed}"));
+		Assert.That(contributor.EmailAddress, Is.EqualTo(emailAddress));
 	}
 
 	[Test]
@@ -40,8 +43,10 @@ internal sealed class ConversionApplicationContributorViewModelTests
 		int applicationId = Fixture.Create<int>();
 		string fullname = Fixture.Create<string>();
 		SchoolRoles schoolRole = SchoolRoles.ChairOfGovernors;
+		string emailAddress = Fixture.Create<string>();
 
-		var contributor = new ConversionApplicationContributorViewModel(contributorId, applicationId, fullname, schoolRole, null);
+		var contributor = new ConversionApplicationContributorViewModel(contributorId, applicationId, 
+			fullname, schoolRole, null, emailAddress);
 
 		// act
 		// nothing!
@@ -52,5 +57,6 @@ internal sealed class ConversionApplicationContributorViewModelTests
 		Assert.That(contributor.ApplicationId, Is.EqualTo(applicationId));
 		Assert.That(contributor.FullName, Is.EqualTo(fullname));
 		Assert.That(contributor.RoleName, Is.EqualTo("The chair of the school's governors"));
+		Assert.That(contributor.EmailAddress, Is.EqualTo(emailAddress));
 	}
 }

--- a/Dfe.Academies.External.Web/Pages/AddAContributor.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/AddAContributor.cshtml.cs
@@ -199,7 +199,8 @@ namespace Dfe.Academies.External.Web.Pages
 																									application.ApplicationId,
 																									e.FullName, 
 																									e.Role, 
-																									e.OtherRoleName))
+																									e.OtherRoleName,
+																									e.EmailAddress))
 						.ToList();
 
 					ExistingContributors = contributors;

--- a/Dfe.Academies.External.Web/Pages/Shared/_ApplicationContributorsPartial.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Shared/_ApplicationContributorsPartial.cshtml
@@ -1,4 +1,10 @@
-﻿@model List<Dfe.Academies.External.Web.ViewModels.ConversionApplicationContributorViewModel>
+﻿@using System.Security.Claims
+@using Microsoft.AspNetCore.Mvc.TagHelpers
+@model List<Dfe.Academies.External.Web.ViewModels.ConversionApplicationContributorViewModel>
+
+@{
+	string currentUserEmail = User.FindFirst(ClaimTypes.Email)?.Value ?? string.Empty;
+}
 
 @if (Model.Count > 0)
 {
@@ -16,11 +22,14 @@
                 <tr class="govuk-table__row">  
                     <th scope="row" class="govuk-table__cell">@contributor.FullName</th>
 	                <td class="govuk-table__cell">@contributor.RoleName</td>
-                    <td class="govuk-table__cell">
-	                    <a asp-page="RemoveAContributorConfirmation" asp-route-appId="@contributor.ApplicationId"
-	                       asp-route-contributorId="@contributor.ContributorId"
-	                       class="govuk-link">Remove contributor</a>
-	                    </td>
+	                <td class="govuk-table__cell">
+                        @if (!string.Equals(currentUserEmail.Trim().ToLower(), contributor.EmailAddress.Trim().ToLower(), StringComparison.Ordinal))
+                        {
+	                        <a asp-page="RemoveAContributorConfirmation" asp-route-appId="@contributor.ApplicationId"
+	                           asp-route-contributorId="@contributor.ContributorId"
+	                           class="govuk-link">Remove contributor</a>
+                        }
+	                </td>
                 </tr>
             }        
         </tbody>

--- a/Dfe.Academies.External.Web/ViewModels/ConversionApplicationContributorViewModel.cs
+++ b/Dfe.Academies.External.Web/ViewModels/ConversionApplicationContributorViewModel.cs
@@ -5,13 +5,15 @@ namespace Dfe.Academies.External.Web.ViewModels;
 
 public sealed class ConversionApplicationContributorViewModel
 {
-	public ConversionApplicationContributorViewModel(int contributorId, int applicationId, string fullName, SchoolRoles role, string? otherRole)
+	public ConversionApplicationContributorViewModel(int contributorId, int applicationId, 
+		string fullName, SchoolRoles role, string? otherRole, string emailAddress)
 	{
 		ContributorId = contributorId;
 		ApplicationId = applicationId;
 		FullName = fullName;
 		Role = role;
 		OtherRoleNotListed = otherRole;
+		EmailAddress = emailAddress;
 	}
 
 	public int ContributorId { get; set; }
@@ -19,6 +21,8 @@ public sealed class ConversionApplicationContributorViewModel
 	public int ApplicationId { get; set; }
 
 	public string FullName { get; }
+
+	public string EmailAddress { get; }
 
 	private SchoolRoles Role { get; }
 


### PR DESCRIPTION
see below ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/113668?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
User is able to remove themselves as a contributor which means they would kick themselves out of the application

## Steps to reproduce issue (if relevant)
1. go to application overview
2. click on invite contributors
3. can see 'remove contributor' link for self

## Steps to test this PR
1. go to application overview
2. click on invite contributors
3. can't see 'remove contributor' link for self

## Prerequisites
n/a
