### PR TITLE
107103 fam trust opening date summary page

### DIFF
--- a/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummaryModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummaryModelTests.cs
@@ -1,0 +1,19 @@
+﻿using AutoFixture;
+using Dfe.Academies.External.Web.Services;
+using Dfe.Academies.External.Web.UnitTest.Factories;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Dfe.Academies.External.Web.Pages.Trust.FormAMat;
+
+namespace Dfe.Academies.External.Web.UnitTest.Pages.Trust.FormAMat;
+
+[Parallelizable(ParallelScope.All)]
+internal sealed class ApplicationNewTrustOpeningDateSummaryModelTests
+{
+	// TODO:-
+}

--- a/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummaryModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummaryModelTests.cs
@@ -15,5 +15,49 @@ namespace Dfe.Academies.External.Web.UnitTest.Pages.Trust.FormAMat;
 [Parallelizable(ParallelScope.All)]
 internal sealed class ApplicationNewTrustOpeningDateSummaryModelTests
 {
-	// TODO:-
+	private static readonly Fixture Fixture = new();
+
+	/// <summary>
+	/// "draftConversionApplication" in temp storage
+	/// from previous step in the new application wizard
+	/// </summary>
+	/// <returns></returns>
+	[Test]
+	public async Task OnGetAsync___Valid___NullErrors()
+	{
+		// arrange
+		var draftConversionApplicationStorageKey = TempDataHelper.DraftConversionApplicationKey;
+		var mockConversionApplicationRetrievalService = new Mock<IConversionApplicationRetrievalService>();
+		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
+		int applicationId = Fixture.Create<int>();
+
+		var conversionApplication = ConversionApplicationTestDataFactory.BuildNewConversionApplicationWithChairRole();
+
+		// act
+		var pageModel = SetupApplicationNewTrustOpeningDateModel(mockConversionApplicationRetrievalService.Object,
+			mockReferenceDataRetrievalService.Object);
+		TempDataHelper.StoreSerialisedValue(draftConversionApplicationStorageKey, pageModel.TempData, conversionApplication);
+
+		// act
+		await pageModel.OnGetAsync(applicationId);
+
+		// assert
+		Assert.That(pageModel.TempData["Errors"], Is.EqualTo(null));
+	}
+
+	private static ApplicationNewTrustOpeningDateSummaryModel SetupApplicationNewTrustOpeningDateModel(
+		IConversionApplicationRetrievalService mockConversionApplicationRetrievalService,
+		IReferenceDataRetrievalService mockReferenceDataRetrievalService,
+		bool isAuthenticated = false)
+	{
+		(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
+
+		return new ApplicationNewTrustOpeningDateSummaryModel(mockConversionApplicationRetrievalService, mockReferenceDataRetrievalService)
+		{
+			PageContext = pageContext,
+			TempData = tempData,
+			Url = new UrlHelper(actionContext),
+			MetadataProvider = pageContext.ViewData.ModelMetadata
+		};
+	}
 }

--- a/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustSummaryModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustSummaryModelTests.cs
@@ -30,7 +30,6 @@ internal sealed class ApplicationNewTrustSummaryModelTests
 		var mockConversionApplicationRetrievalService = new Mock<IConversionApplicationRetrievalService>();
 		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
 		int applicationId = Fixture.Create<int>();
-		int urn = Fixture.Create<int>();
 
 		var conversionApplication = ConversionApplicationTestDataFactory.BuildNewConversionApplicationWithChairRole();
 
@@ -40,7 +39,7 @@ internal sealed class ApplicationNewTrustSummaryModelTests
 		TempDataHelper.StoreSerialisedValue(draftConversionApplicationStorageKey, pageModel.TempData, conversionApplication);
 
 		// act
-		await pageModel.OnGetAsync(urn, applicationId);
+		await pageModel.OnGetAsync(applicationId);
 
 		// assert
 		Assert.That(pageModel.TempData["Errors"], Is.EqualTo(null));

--- a/Dfe.Academies.External.Web/Pages/Base/BaseTrustFAMApplicationSummaryPageModel.cs
+++ b/Dfe.Academies.External.Web/Pages/Base/BaseTrustFAMApplicationSummaryPageModel.cs
@@ -1,0 +1,48 @@
+﻿using Dfe.Academies.External.Web.Models;
+using Dfe.Academies.External.Web.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dfe.Academies.External.Web.Pages.Base
+{
+	public abstract class BaseTrustFamApplicationSummaryPageModel : BasePageEditModel
+	{
+		[BindProperty]
+		public int ApplicationId { get; set; }
+
+		public string TrustName { get; set; } = string.Empty;
+
+		protected BaseTrustFamApplicationSummaryPageModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService,
+			IReferenceDataRetrievalService referenceDataRetrievalService)
+			: base(conversionApplicationRetrievalService, referenceDataRetrievalService)
+		{
+		}
+
+		public virtual async Task<ActionResult> OnGetAsync(int urn, int appId)
+		{
+			// MR:- don't need try/catch anymore as we have exception middleware
+			LoadAndStoreCachedConversionApplication();
+
+			// check user access
+			var checkStatus = await CheckApplicationPermission(appId);
+
+			if (checkStatus is ForbidResult)
+			{
+				return RedirectToPage("../ApplicationAccessException");
+			}
+
+			ApplicationId = appId;
+			
+			var conversionApplication = TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey, TempData) ?? new ConversionApplication();
+
+			PopulateUiModel(conversionApplication);
+
+			return Page();
+		}
+
+		/// <summary>
+		/// take application data from API and populate UI controls
+		/// </summary>
+		/// <param name="conversionApplication"></param>
+		public abstract void PopulateUiModel(ConversionApplication? conversionApplication);
+	}
+}

--- a/Dfe.Academies.External.Web/Pages/Base/BaseTrustFAMApplicationSummaryPageModel.cs
+++ b/Dfe.Academies.External.Web/Pages/Base/BaseTrustFAMApplicationSummaryPageModel.cs
@@ -17,7 +17,7 @@ namespace Dfe.Academies.External.Web.Pages.Base
 		{
 		}
 
-		public virtual async Task<ActionResult> OnGetAsync(int urn, int appId)
+		public virtual async Task<ActionResult> OnGetAsync(int appId)
 		{
 			// MR:- don't need try/catch anymore as we have exception middleware
 			LoadAndStoreCachedConversionApplication();

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustName.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustName.cshtml.cs
@@ -11,7 +11,7 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 		//// MR:- VM props to capture data -
 
 		[BindProperty]
-		[Required(ErrorMessage = "Please enter the Trust name")]
+		[Required(ErrorMessage = "You must provide details")]
 		public string? ProposedNameOfTrust { get; set; }
 
 		public ApplicationNewTrustNameModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService, 

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDate.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDate.cshtml.cs
@@ -57,7 +57,7 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 
 		public ApplicationNewTrustOpeningDateModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService, 
 			IReferenceDataRetrievalService referenceDataRetrievalService, IConversionApplicationCreationService conversionApplicationCreationService) 
-			: base(conversionApplicationRetrievalService, referenceDataRetrievalService, conversionApplicationCreationService, "TBC")
+			: base(conversionApplicationRetrievalService, referenceDataRetrievalService, conversionApplicationCreationService, "ApplicationNewTrustOpeningDateSummary")
 		{
 		}
 

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml
@@ -13,9 +13,9 @@
 	<span class="govuk-caption-l">
 		@Model.TrustName
 	</span>
-    <h1 class="govuk-heading-l">Trust opening date summary</h1>
+    <h1 class="govuk-heading-l">Opening date</h1>
     
-    CONTENT !!!
+    CONTENT !!! Just one section
 
 	<a asp-page="../../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml
@@ -1,0 +1,23 @@
+﻿@page
+@model Dfe.Academies.External.Web.Pages.Trust.FormAMat.ApplicationNewTrustOpeningDateSummaryModel
+@{
+	ViewData["Title"] = "Apply to become an academy - Trust opening date summary";
+}
+
+@section BeforeMain
+{
+	<a asp-page="../../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back to application overview</a>
+}
+
+<div class="govuk-grid-column-full">
+	<span class="govuk-caption-l">
+		@Model.TrustName
+	</span>
+    <h1 class="govuk-heading-l">Trust opening date summary</h1>
+    
+    CONTENT !!!
+
+	<a asp-page="../../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
+</div>
+
+<partial name="_HiddenFields" />

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml
@@ -8,7 +8,7 @@
 
 @section BeforeMain
 {
-	<a asp-page="../../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back to application overview</a>
+    <a asp-page="ApplicationNewTrustSummary" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back to application overview</a>
 }
 
 <div class="govuk-grid-column-full">
@@ -58,7 +58,7 @@
 		<div class="govuk-!-margin-6"></div>
 	}
 
-	<a asp-page="../../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
+    <a asp-page="ApplicationNewTrustSummary" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
 
 <partial name="_HiddenFields" />

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml
@@ -16,10 +16,17 @@
 		@Model.TrustName
 	</span>
     <h1 class="govuk-heading-l">Opening date</h1>
-    
+
+@*    <p id="summaryTableDescription" class="govuk-body">Trust opening date summary</p>*@
 	@foreach (var question in Model.ViewModel)
 	{
-		<table class="govuk-table">
+		<table class="govuk-table" aria-describedby="summaryTableDescription">
+			<thead>
+				<tr>
+					<th scope="col"></th>
+					<th scope="col"></th>
+				</tr>
+			</thead>
 			<tbody class="govuk-table__body">
 			<tr class="govuk-table__row">
 				<td class="govuk-table__cell">
@@ -42,11 +49,12 @@
 			</tr>
 			@foreach (var conversionComponent in question.Sections)
 			{
-				<partial name="_SchoolConversionComponentPartial" model="@conversionComponent" />
+				<partial name="_SchoolConversionComponentPartial" model="@conversionComponent"/>
 			}
 
 			</tbody>
 		</table>
+
 		<div class="govuk-!-margin-6"></div>
 	}
 

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml
@@ -1,4 +1,6 @@
 ﻿@page
+@using Dfe.Academies.External.Web.Enums
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model Dfe.Academies.External.Web.Pages.Trust.FormAMat.ApplicationNewTrustOpeningDateSummaryModel
 @{
 	ViewData["Title"] = "Apply to become an academy - Trust opening date summary";
@@ -15,7 +17,38 @@
 	</span>
     <h1 class="govuk-heading-l">Opening date</h1>
     
-    CONTENT !!! Just one section
+	@foreach (var question in Model.ViewModel)
+	{
+		<table class="govuk-table">
+			<tbody class="govuk-table__body">
+			<tr class="govuk-table__row">
+				<td class="govuk-table__cell">
+					@if (question.Status == SchoolConversionComponentStatus.NotStarted)
+					{
+						<a asp-page="@question.URI" aria-describedby="component-not started" class="govuk-button govuk-button--secondary"
+						   asp-route-appId="@Model.ApplicationId">
+							Start section
+						</a>
+					}
+					else
+					{
+						<a asp-page="@question.URI" aria-describedby="component-change" class="govuk-link"
+						   asp-route-appId="@Model.ApplicationId">
+							Change your answers
+						</a>
+					}
+				</td>
+				<td class="govuk-table__cell"></td>
+			</tr>
+			@foreach (var conversionComponent in question.Sections)
+			{
+				<partial name="_SchoolConversionComponentPartial" model="@conversionComponent" />
+			}
+
+			</tbody>
+		</table>
+		<div class="govuk-!-margin-6"></div>
+	}
 
 	<a asp-page="../../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml.cs
@@ -1,6 +1,9 @@
-﻿using Dfe.Academies.External.Web.Models;
+﻿using Dfe.Academies.External.Web.Enums;
+using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
+using Dfe.Academies.External.Web.ViewModels;
+using Dfe.Academies.External.Web.ViewModels.TrustSummaryPages;
 
 namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 {
@@ -9,7 +12,10 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 	/// </summary>
 	public class ApplicationNewTrustOpeningDateSummaryModel : BaseTrustFamApplicationSummaryPageModel
 	{
-        public ApplicationNewTrustOpeningDateSummaryModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService, 
+		//// MR:- VM props to show school conversion data
+		public List<ApplicationNewTrustOpeningDateHeadingViewModel> ViewModel { get; set; } = new();
+
+		public ApplicationNewTrustOpeningDateSummaryModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService, 
 													IReferenceDataRetrievalService referenceDataRetrievalService) 
 	        : base(conversionApplicationRetrievalService, referenceDataRetrievalService)
         {
@@ -42,25 +48,24 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 	        {
 		        TrustName = conversionApplication.FormTrustDetails.FormTrustProposedNameOfTrust;
 
-				// TODO:- pop summary VM - same as other summary pages
-				//ApplicationPreOpeningSupportGrantHeadingViewModel heading1 = new(ApplicationPreOpeningSupportGrantHeadingViewModel.Heading, // heading = 'Details'
-				//	"/Trust/FormAMat/ApplicationNewTrustOpeningDate")
-				//{
-				//	Status = conversionApplication.FormTrustDetails.FormTrustOpeningDate.HasValue ?
-				//		SchoolConversionComponentStatus.Complete
-				//		: SchoolConversionComponentStatus.NotStarted
-				//};
+				ApplicationNewTrustOpeningDateHeadingViewModel heading1 = new(ApplicationNewTrustOpeningDateHeadingViewModel.Heading, // heading = 'Details'
+					"/Trust/FormAMat/ApplicationNewTrustOpeningDate")
+				{
+					Status = conversionApplication.FormTrustDetails.FormTrustOpeningDate.HasValue ?
+						SchoolConversionComponentStatus.Complete
+						: SchoolConversionComponentStatus.NotStarted
+				};
 
-				//heading1.Sections.Add(new(
-				//	ApplicationPreOpeningSupportGrantSectionViewModel.FundsSchoolOrTrust,
-				//	!conversionApplication.FormTrustDetails.FormTrustOpeningDate.HasValue ?
-				//		QuestionAndAnswerConstants.NoInfoAnswer :
-				//		conversionApplication.FormTrustDetails.FormTrustOpeningDate.Value.ToString("dd/MM/yyyy") ?? string.Empty
-				//));
+				heading1.Sections.Add(new(
+					ApplicationNewTrustOpeningDateSectionViewModel.OpeningDate,
+					!conversionApplication.FormTrustDetails.FormTrustOpeningDate.HasValue ?
+						QuestionAndAnswerConstants.NoInfoAnswer :
+						conversionApplication.FormTrustDetails.FormTrustOpeningDate.Value.ToString("dd/MM/yyyy")
+				));
 
-				//var vm = new List<ApplicationPreOpeningSupportGrantHeadingViewModel> { heading1 };
+				var vm = new List<ApplicationNewTrustOpeningDateHeadingViewModel> { heading1 };
 
-				//ViewModel = vm;
+				ViewModel = vm;
 			}
 		}
 	}

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml.cs
@@ -63,12 +63,19 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 						conversionApplication.FormTrustDetails.FormTrustOpeningDate.Value.ToString("dd/MM/yyyy")
 				));
 
-				// TODO:- 2 more sections !!!
-				// approver full name
-				// ApplicationNewTrustOpeningDateSectionViewModel.ApproverFullname
+				heading1.Sections.Add(new(
+					ApplicationNewTrustOpeningDateSectionViewModel.ApproverFullname,
+					(string.IsNullOrWhiteSpace(conversionApplication.FormTrustDetails.TrustApproverName) ?
+						QuestionAndAnswerConstants.NoInfoAnswer :
+						conversionApplication.FormTrustDetails.TrustApproverName)
+				));
 
-				// approver email
-				// ApplicationNewTrustOpeningDateSectionViewModel.ApproverEmail
+				heading1.Sections.Add(new(
+					ApplicationNewTrustOpeningDateSectionViewModel.ApproverEmail,
+					(string.IsNullOrWhiteSpace(conversionApplication.FormTrustDetails.TrustApproverEmail) ?
+						QuestionAndAnswerConstants.NoInfoAnswer :
+						conversionApplication.FormTrustDetails.TrustApproverEmail)
+				));
 
 				var vm = new List<ApplicationNewTrustOpeningDateHeadingViewModel> { heading1 };
 

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml.cs
@@ -63,6 +63,13 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 						conversionApplication.FormTrustDetails.FormTrustOpeningDate.Value.ToString("dd/MM/yyyy")
 				));
 
+				// TODO:- 2 more sections !!!
+				// approver full name
+				// ApplicationNewTrustOpeningDateSectionViewModel.ApproverFullname
+
+				// approver email
+				// ApplicationNewTrustOpeningDateSectionViewModel.ApproverEmail
+
 				var vm = new List<ApplicationNewTrustOpeningDateHeadingViewModel> { heading1 };
 
 				ViewModel = vm;

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml.cs
@@ -1,0 +1,49 @@
+﻿using Dfe.Academies.External.Web.Models;
+using Dfe.Academies.External.Web.Pages.Base;
+using Dfe.Academies.External.Web.Services;
+
+namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
+{
+	/// <summary>
+	/// replica of TrustOpeningDateReview.cshtml
+	/// </summary>
+	public class ApplicationNewTrustOpeningDateSummaryModel : BaseTrustFamApplicationSummaryPageModel
+	{
+        public ApplicationNewTrustOpeningDateSummaryModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService, 
+													IReferenceDataRetrievalService referenceDataRetrievalService) 
+	        : base(conversionApplicationRetrievalService, referenceDataRetrievalService)
+        {
+        }
+
+        ///<inheritdoc/>
+		public override void PopulateValidationMessages()
+        {
+	        PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+        ///<inheritdoc/>
+		public override bool RunUiValidation()
+        {
+	        // does not apply on this page
+	        return true;
+		}
+
+        ///<inheritdoc/>
+        public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+        {
+	        // does not apply on this page
+	        return new();
+        }
+
+        ///<inheritdoc/>
+		public override void PopulateUiModel(ConversionApplication? conversionApplication)
+        {
+	        if (conversionApplication != null && conversionApplication.FormTrustDetails != null)
+	        {
+		        TrustName = conversionApplication.FormTrustDetails.FormTrustProposedNameOfTrust;
+		        
+				// TODO:- pop summary VM - same as other summary pages
+	        }
+		}
+	}
+}

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml.cs
@@ -41,9 +41,27 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 	        if (conversionApplication != null && conversionApplication.FormTrustDetails != null)
 	        {
 		        TrustName = conversionApplication.FormTrustDetails.FormTrustProposedNameOfTrust;
-		        
+
 				// TODO:- pop summary VM - same as other summary pages
-	        }
+				//ApplicationPreOpeningSupportGrantHeadingViewModel heading1 = new(ApplicationPreOpeningSupportGrantHeadingViewModel.Heading, // heading = 'Details'
+				//	"/Trust/FormAMat/ApplicationNewTrustOpeningDate")
+				//{
+				//	Status = conversionApplication.FormTrustDetails.FormTrustOpeningDate.HasValue ?
+				//		SchoolConversionComponentStatus.Complete
+				//		: SchoolConversionComponentStatus.NotStarted
+				//};
+
+				//heading1.Sections.Add(new(
+				//	ApplicationPreOpeningSupportGrantSectionViewModel.FundsSchoolOrTrust,
+				//	!conversionApplication.FormTrustDetails.FormTrustOpeningDate.HasValue ?
+				//		QuestionAndAnswerConstants.NoInfoAnswer :
+				//		conversionApplication.FormTrustDetails.FormTrustOpeningDate.Value.ToString("dd/MM/yyyy") ?? string.Empty
+				//));
+
+				//var vm = new List<ApplicationPreOpeningSupportGrantHeadingViewModel> { heading1 };
+
+				//ViewModel = vm;
+			}
 		}
 	}
 }

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustSummary.cshtml.cs
@@ -5,7 +5,7 @@ using Dfe.Academies.External.Web.Services;
 
 namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 {
-    public class ApplicationNewTrustSummaryModel : BaseApplicationSummaryPageModel
+    public class ApplicationNewTrustSummaryModel : BaseTrustFamApplicationSummaryPageModel
 	{
 		public ApplicationTypes ApplicationType { get; private set; }
 
@@ -40,7 +40,7 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
         {
 	        if (conversionApplication != null && conversionApplication.FormTrustDetails != null)
 	        {
-				//ProposedNameOfTrust = conversionApplication.FormTrustDetails.FormTrustProposedNameOfTrust;
+				TrustName = conversionApplication.FormTrustDetails.FormTrustProposedNameOfTrust;
 				ApplicationType = conversionApplication.ApplicationType;
 			}
         }

--- a/Dfe.Academies.External.Web/ViewModels/SummaryPages/ApplicationSchoolJoinAMatTrustSummarySectionViewModel.cs
+++ b/Dfe.Academies.External.Web/ViewModels/SummaryPages/ApplicationSchoolJoinAMatTrustSummarySectionViewModel.cs
@@ -7,8 +7,6 @@
 		public const string ChangesToTrustGovernance = "Will there be any changes to the governance of the trust due to the school joining?";
 		public const string ChangesToLaGovernance = "Will there be any changes at a local level due to this school joining?";
 
-		//ChangesToLaGovernance
-
 		public ApplicationSchoolJoinAMatTrustSummarySectionViewModel(string name, string answer) : base(name, answer)
 		{
 		}

--- a/Dfe.Academies.External.Web/ViewModels/TrustSummaryPages/ApplicationNewTrustOpeningDateHeadingViewModel.cs
+++ b/Dfe.Academies.External.Web/ViewModels/TrustSummaryPages/ApplicationNewTrustOpeningDateHeadingViewModel.cs
@@ -1,0 +1,14 @@
+﻿namespace Dfe.Academies.External.Web.ViewModels.TrustSummaryPages
+{
+	public sealed class ApplicationNewTrustOpeningDateHeadingViewModel : SchoolQuestionAndAnswerSectionViewModel
+	{
+		public const string Heading = "Details";
+
+		public ApplicationNewTrustOpeningDateHeadingViewModel(string title, string uRi) : base(title, uRi)
+		{
+			Sections = new();
+		}
+
+		public List<ApplicationNewTrustOpeningDateSectionViewModel> Sections { get; set; }
+	}
+}

--- a/Dfe.Academies.External.Web/ViewModels/TrustSummaryPages/ApplicationNewTrustOpeningDateSectionViewModel.cs
+++ b/Dfe.Academies.External.Web/ViewModels/TrustSummaryPages/ApplicationNewTrustOpeningDateSectionViewModel.cs
@@ -1,0 +1,11 @@
+﻿namespace Dfe.Academies.External.Web.ViewModels.TrustSummaryPages
+{
+	public sealed class ApplicationNewTrustOpeningDateSectionViewModel : SchoolQuestionAndAnswerViewModel
+	{
+		public const string OpeningDate = "The name of the trust"; // TODO:- fix up
+
+		public ApplicationNewTrustOpeningDateSectionViewModel(string name, string answer) : base(name, answer)
+		{
+		}
+	}
+}

--- a/Dfe.Academies.External.Web/ViewModels/TrustSummaryPages/ApplicationNewTrustOpeningDateSectionViewModel.cs
+++ b/Dfe.Academies.External.Web/ViewModels/TrustSummaryPages/ApplicationNewTrustOpeningDateSectionViewModel.cs
@@ -2,7 +2,9 @@
 {
 	public sealed class ApplicationNewTrustOpeningDateSectionViewModel : SchoolQuestionAndAnswerViewModel
 	{
-		public const string OpeningDate = "The name of the trust"; // TODO:- fix up
+		public const string OpeningDate = "When do the schools plan to establish the new multi-academy trust?";
+		public const string ApproverFullname = "Approver full name";
+		public const string ApproverEmail = "Approver email address";
 
 		public ApplicationNewTrustOpeningDateSectionViewModel(string name, string answer) : base(name, answer)
 		{


### PR DESCRIPTION
See ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/107013

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
New fam trust opening date summary page to show input fam trust opening date data

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. Page is called from FAM Trust overview page which doesn't exist yet
2. So, to preview page, go to URL directly:- https://localhost:44350/trust/form-amat/application-new-trust-opening-date-summary?appId=7

## Prerequisites
n/a
