### PR TITLE
fix to handle if existing trust data already exists

### DIFF
--- a/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
+++ b/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
@@ -143,8 +143,20 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 			//// https://s184d01-aca-aca-app.nicedesert-a691fec6.westeurope.azurecontainerapps.io/application/99/join-trust
 			string apiurl = $"{_httpClient.BaseAddress}application/{applicationId}/join-trust?api-version=V1";
 
-			var trust = new ExistingTrust(applicationId, name, trustUkPrn);
-
+			ExistingTrust trust;
+			if (application.JoinTrustDetails != null)
+			{
+				trust = new ExistingTrust(applicationId, name, trustUkPrn,
+					application.JoinTrustDetails.ChangesToTrust,
+					application.JoinTrustDetails.ChangesToTrustExplained,
+					application.JoinTrustDetails.ChangesToLaGovernance,
+					application.JoinTrustDetails.ChangesToLaGovernanceExplained);
+			}
+			else
+			{
+				trust = new ExistingTrust(applicationId, name, trustUkPrn);
+			}
+			
 			// MR:- no response from Academies API - Just an OK
 			await _resilientRequestProvider.PutAsync(apiurl, trust);
 		}


### PR DESCRIPTION
Fix the following issue:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/113895?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
FAM - When you go into trust details and change the trust you are joining by selecting a different one, all other trust details are wiped. they shouldn't be

## Steps to reproduce issue (if relevant)
1. FAM - When you go into trust details and change the trust you are joining by selecting a different one, all other trust details are wiped. they shouldn't be

## Steps to test this PR
1. FAM - When you go into trust details and change the trust you are joining by selecting a different one, 
2. then go into trust details summary page, details not wiped
3.
4.

## Prerequisites
n/a
