### PR TITLE
107019 - FAM - Trust reasons for forming the trust (details) page

### DIFF
--- a/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustReasonsModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustReasonsModelTests.cs
@@ -1,9 +1,67 @@
-﻿using NUnit.Framework;
+﻿using AutoFixture;
+using Dfe.Academies.External.Web.Pages.Trust.FormAMat;
+using Dfe.Academies.External.Web.Services;
+using Dfe.Academies.External.Web.UnitTest.Factories;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System.Threading.Tasks;
+using NUnit.Framework;
 
 namespace Dfe.Academies.External.Web.UnitTest.Pages.Trust.FormAMat;
 
 [Parallelizable(ParallelScope.All)]
 internal sealed class ApplicationNewTrustReasonsModelTests
 {
-	// TODO:-
+	private static readonly Fixture Fixture = new();
+
+	/// <summary>
+	/// "draftConversionApplication" in temp storage
+	/// from previous step in the new application wizard
+	/// </summary>
+	/// <returns></returns>
+	[Test]
+	public async Task OnGetAsync___Valid___NullErrors()
+	{
+		// arrange
+		var draftConversionApplicationStorageKey = TempDataHelper.DraftConversionApplicationKey;
+		var mockConversionApplicationRetrievalService = new Mock<IConversionApplicationRetrievalService>();
+		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
+		var mockConversionApplicationCreationService = new Mock<IConversionApplicationCreationService>();
+		int applicationId = Fixture.Create<int>();
+
+		var conversionApplication = ConversionApplicationTestDataFactory.BuildNewConversionApplicationWithChairRole();
+
+		// act
+		var pageModel = SetupApplicationNewTrustReasonsModel(mockConversionApplicationRetrievalService.Object,
+			mockReferenceDataRetrievalService.Object,
+			mockConversionApplicationCreationService.Object);
+		TempDataHelper.StoreSerialisedValue(draftConversionApplicationStorageKey, pageModel.TempData, conversionApplication);
+
+		// act
+		await pageModel.OnGetAsync(applicationId);
+
+		// assert
+		Assert.That(pageModel.TempData["Errors"], Is.EqualTo(null));
+	}
+
+	private static ApplicationNewTrustReasonsModel SetupApplicationNewTrustReasonsModel(
+		IConversionApplicationRetrievalService mockConversionApplicationRetrievalService,
+		IReferenceDataRetrievalService mockReferenceDataRetrievalService,
+		IConversionApplicationCreationService mockConversionApplicationCreationService,
+		bool isAuthenticated = false)
+	{
+		(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
+
+		return new ApplicationNewTrustReasonsModel(mockConversionApplicationRetrievalService, mockReferenceDataRetrievalService,
+			mockConversionApplicationCreationService, "")
+		{
+			PageContext = pageContext,
+			TempData = tempData,
+			Url = new UrlHelper(actionContext),
+			MetadataProvider = pageContext.ViewData.ModelMetadata
+		};
+	}
 }

--- a/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustReasonsModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustReasonsModelTests.cs
@@ -56,7 +56,7 @@ internal sealed class ApplicationNewTrustReasonsModelTests
 		(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
 
 		return new ApplicationNewTrustReasonsModel(mockConversionApplicationRetrievalService, mockReferenceDataRetrievalService,
-			mockConversionApplicationCreationService, "")
+			mockConversionApplicationCreationService)
 		{
 			PageContext = pageContext,
 			TempData = tempData,

--- a/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustReasonsModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustReasonsModelTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace Dfe.Academies.External.Web.UnitTest.Pages.Trust.FormAMat;
+
+[Parallelizable(ParallelScope.All)]
+internal sealed class ApplicationNewTrustReasonsModelTests
+{
+	// TODO:-
+}

--- a/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustReasonsSummaryModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustReasonsSummaryModelTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace Dfe.Academies.External.Web.UnitTest.Pages.Trust.FormAMat;
+
+[Parallelizable(ParallelScope.All)]
+internal sealed class ApplicationNewTrustReasonsSummaryModelTests
+{
+	// TODO:-
+}

--- a/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
+++ b/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
@@ -108,13 +108,13 @@ public abstract class BasePageEditModel : BasePageModel
 	{
 		return componentName.ToLower().Trim() switch
 		{
-			"name of the trust" => "applicationnewtrustname",
-			"opening date" => "applicationnewtrustopeningdatesummary",
-			"reasons for forming the trust" => "ApplicationNewTrustReason",
-			"plans for growth" => "/formamat/applicationnewtrustplansforgrowth",
-			"school improvement strategy" => "/formamat/applicationnewtrustschoolimprovement",
-			"governance structure" => "/formamat/applicationnewtrustgovernancestructure",
-			"key people" => "/formamat/applicationnewtrustkeypeople",
+			"name of the trust" => "/trust/formamat/applicationnewtrustname",
+			"opening date" => "/trust/formamat/applicationnewtrustopeningdatesummary",
+			"reasons for forming the trust" => "/trust/formamat/ApplicationNewTrustReasonsSummary",
+			"plans for growth" => "/trust/formamat/applicationnewtrustplansforgrowth",
+			"school improvement strategy" => "/trust/formamat/applicationnewtrustschoolimprovement",
+			"governance structure" => "/trust/formamat/applicationnewtrustgovernancestructure",
+			"key people" => "/trust/formamat/applicationnewtrustkeypeople",
 			_ => string.Empty
 		};
 	}

--- a/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
+++ b/Dfe.Academies.External.Web/Pages/Base/BasePageEditModel.cs
@@ -110,7 +110,7 @@ public abstract class BasePageEditModel : BasePageModel
 		{
 			"name of the trust" => "applicationnewtrustname",
 			"opening date" => "applicationnewtrustopeningdatesummary",
-			"reasons for forming the trust" => "/formamat/applicationnewtrustreason",
+			"reasons for forming the trust" => "ApplicationNewTrustReason",
 			"plans for growth" => "/formamat/applicationnewtrustplansforgrowth",
 			"school improvement strategy" => "/formamat/applicationnewtrustschoolimprovement",
 			"governance structure" => "/formamat/applicationnewtrustgovernancestructure",

--- a/Dfe.Academies.External.Web/Pages/School/LeaseDetails.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/LeaseDetails.cshtml
@@ -1,7 +1,4 @@
 ﻿@page
-@using Dfe.Academies.External.Web.Enums
-@using Dfe.Academies.External.Web.Extensions
-@using Dfe.Academies.External.Web.TagHelpers
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @model Dfe.Academies.External.Web.Pages.School.LeaseDetails
 @{

--- a/Dfe.Academies.External.Web/Pages/School/Leases.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/Leases.cshtml
@@ -1,7 +1,6 @@
 ﻿@page
 @using Dfe.Academies.External.Web.Enums
 @using Dfe.Academies.External.Web.Extensions
-@using Dfe.Academies.External.Web.TagHelpers
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @model Dfe.Academies.External.Web.Pages.School.Leases
 @{

--- a/Dfe.Academies.External.Web/Pages/School/LoanDetails.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/LoanDetails.cshtml
@@ -1,7 +1,4 @@
 ﻿@page
-@using Dfe.Academies.External.Web.Enums
-@using Dfe.Academies.External.Web.Extensions
-@using Dfe.Academies.External.Web.TagHelpers
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @model Dfe.Academies.External.Web.Pages.School.LoanDetails
 @{

--- a/Dfe.Academies.External.Web/Pages/School/Loans.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/Loans.cshtml
@@ -2,7 +2,6 @@
 @using Dfe.Academies.External.Web.Enums
 @using Dfe.Academies.External.Web.Extensions
 @using Microsoft.AspNetCore.Mvc.TagHelpers
-@using System.Globalization
 @model Dfe.Academies.External.Web.Pages.School.Loans
 @{
 	ViewData["Title"] = "Apply to become an academy - About the conversion";

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml
@@ -27,32 +27,32 @@
 				</div>
 
 				<div class="govuk-form-group">
-					<label for="ReasonForming" class="govuk-label">Why are the schools forming the trust?</label>
-                    <p class="govuk-caption-l">This could include the expected benefits or existing links you are building on.</p>
+                    <label for="ReasonForming" class="govuk-label govuk-!-font-weight-bold">Why are the schools forming the trust?</label>
+                    <p class="govuk-caption-m">This could include the expected benefits or existing links you are building on.</p>
                     <textarea asp-for="ReasonForming" id="ReasonForming"
                               class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
 				</div>
 
 				<div class="govuk-form-group">
-                    <label for="ReasonVision" class="govuk-label">What vision and aspiration have the schools agreed for the trust?</label>
+                    <label for="ReasonVision" class="govuk-label govuk-!-font-weight-bold">What vision and aspiration have the schools agreed for the trust?</label>
                     <textarea asp-for="ReasonVision" id="ReasonVision"
                               class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
                 </div>
                 
                 <div class="govuk-form-group">
-                    <label for="GeoAreas" class="govuk-label">What geographical areas and communities will the trust service?</label>
+                    <label for="GeoAreas" class="govuk-label govuk-!-font-weight-bold">What geographical areas and communities will the trust service?</label>
                     <textarea asp-for="GeoAreas" id="GeoAreas"
                               class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
                 </div>
                 
                 <div class="govuk-form-group">
-                    <label for="Freedom" class="govuk-label">How will the schools make the most of the freedoms that academies have?</label>
+                    <label for="Freedom" class="govuk-label govuk-!-font-weight-bold">How will the schools make the most of the freedoms that academies have?</label>
                     <textarea asp-for="Freedom" id="Freedom"
                               class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
                 </div>
 
                 <div class="govuk-form-group">
-                    <label for="ImproveTeaching" class="govuk-label">How will the schools work together to improve teaching and learning in the trust and potentially support other schools beyond the trust?</label>
+                    <label for="ImproveTeaching" class="govuk-label govuk-!-font-weight-bold">How will the schools work together to improve teaching and learning in the trust and potentially support other schools beyond the trust?</label>
                     <textarea asp-for="ImproveTeaching" id="ImproveTeaching"
                               class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
                 </div>

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml
@@ -6,7 +6,7 @@
 
 @section BeforeMain
 {
-	<a asp-page="ApplicationNewTrustOpeningDateSummary" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back</a>
+    <a asp-page="ApplicationNewTrustReasonsSummary" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back</a>
 }
 
 <div class="govuk-grid-column-two-thirds">

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml
@@ -25,13 +25,16 @@
 				<div class="@(!ViewData.ModelState.IsValid ? "govuk-visually-hidden" : "")">
 					<partial name="_ValidationSummary" model="Model.ValidationErrorMessagesViewModel"/>
 				</div>
-                
-                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Why are the schools forming the trust?</legend>
-                
-                // what is top big textbox?
 
 				<div class="govuk-form-group">
-                    <label for="FormTrustReasonVision" class="govuk-label">What vision and aspiration have the schools agreed for the trust?</label>
+					<label for="ReasonForming" class="govuk-label">Why are the schools forming the trust?</label>
+                    *** grey text ***
+                    <textarea asp-for="ReasonForming" id="ReasonForming"
+                              class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
+				</div>
+
+				<div class="govuk-form-group">
+                    <label for="ReasonVision" class="govuk-label">What vision and aspiration have the schools agreed for the trust?</label>
                     <textarea asp-for="ReasonVision" id="ReasonVision"
                               class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
                 </div>

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml
@@ -1,7 +1,7 @@
 ﻿@page
 @model Dfe.Academies.External.Web.Pages.Trust.FormAMat.ApplicationNewTrustReasonsModel
 @{
-	ViewData["Title"] = "Apply to become an academy - New trusts reasons";
+	ViewData["Title"] = "Apply to become an academy - New trust reasons";
 }
 
 @section BeforeMain
@@ -28,7 +28,7 @@
 
 				<div class="govuk-form-group">
 					<label for="ReasonForming" class="govuk-label">Why are the schools forming the trust?</label>
-                    *** grey text ***
+                    <p class="govuk-caption-l">This could include the expected benefits or existing links you are building on.</p>
                     <textarea asp-for="ReasonForming" id="ReasonForming"
                               class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
 				</div>

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml
@@ -22,40 +22,41 @@
         
 		<div class="@(!ViewData.ModelState.IsValid ? "govuk-form-group--error" : "")">
 			<fieldset class="govuk-fieldset">
+                <legend></legend>
 				<div class="@(!ViewData.ModelState.IsValid ? "govuk-visually-hidden" : "")">
 					<partial name="_ValidationSummary" model="Model.ValidationErrorMessagesViewModel"/>
 				</div>
 
 				<div class="govuk-form-group">
-                    <label for="ReasonForming" class="govuk-label govuk-!-font-weight-bold">Why are the schools forming the trust?</label>
-                    <p class="govuk-caption-m">This could include the expected benefits or existing links you are building on.</p>
-                    <textarea asp-for="ReasonForming" id="ReasonForming"
+					<label for="ReasonForming" class="govuk-label govuk-!-font-weight-bold">Why are the schools forming the trust?</label>
+					<p class="govuk-caption-m">This could include the expected benefits or existing links you are building on.</p>
+					<textarea asp-for="ReasonForming" id="ReasonForming"
                               class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
 				</div>
 
 				<div class="govuk-form-group">
-                    <label for="ReasonVision" class="govuk-label govuk-!-font-weight-bold">What vision and aspiration have the schools agreed for the trust?</label>
-                    <textarea asp-for="ReasonVision" id="ReasonVision"
+					<label for="ReasonVision" class="govuk-label govuk-!-font-weight-bold">What vision and aspiration have the schools agreed for the trust?</label>
+					<textarea asp-for="ReasonVision" id="ReasonVision"
                               class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
-                </div>
-                
-                <div class="govuk-form-group">
-                    <label for="GeoAreas" class="govuk-label govuk-!-font-weight-bold">What geographical areas and communities will the trust service?</label>
-                    <textarea asp-for="GeoAreas" id="GeoAreas"
-                              class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
-                </div>
-                
-                <div class="govuk-form-group">
-                    <label for="Freedom" class="govuk-label govuk-!-font-weight-bold">How will the schools make the most of the freedoms that academies have?</label>
-                    <textarea asp-for="Freedom" id="Freedom"
-                              class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
-                </div>
+				</div>
 
-                <div class="govuk-form-group">
-                    <label for="ImproveTeaching" class="govuk-label govuk-!-font-weight-bold">How will the schools work together to improve teaching and learning in the trust and potentially support other schools beyond the trust?</label>
-                    <textarea asp-for="ImproveTeaching" id="ImproveTeaching"
+				<div class="govuk-form-group">
+					<label for="GeoAreas" class="govuk-label govuk-!-font-weight-bold">What geographical areas and communities will the trust service?</label>
+					<textarea asp-for="GeoAreas" id="GeoAreas"
                               class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
-                </div>
+				</div>
+
+				<div class="govuk-form-group">
+					<label for="Freedom" class="govuk-label govuk-!-font-weight-bold">How will the schools make the most of the freedoms that academies have?</label>
+					<textarea asp-for="Freedom" id="Freedom"
+                              class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
+				</div>
+
+				<div class="govuk-form-group">
+					<label for="ImproveTeaching" class="govuk-label govuk-!-font-weight-bold">How will the schools work together to improve teaching and learning in the trust and potentially support other schools beyond the trust?</label>
+					<textarea asp-for="ImproveTeaching" id="ImproveTeaching"
+                              class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
+				</div>
 			</fieldset>
 		</div>        
 

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml
@@ -1,0 +1,35 @@
+﻿@page
+@model Dfe.Academies.External.Web.Pages.Trust.FormAMat.ApplicationNewTrustReasonsModel
+@{
+	ViewData["Title"] = "Apply to become an academy - New trusts reasons";
+}
+
+@section BeforeMain
+{
+	<a asp-page="ApplicationNewTrustOpeningDateSummary" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back</a>
+}
+
+<div class="govuk-grid-column-two-thirds">
+	<h1 class="govuk-heading-l">
+		<span class="govuk-caption-l">@Model.TrustName</span>
+		Reasons for forming the trust
+	</h1>
+
+	<form method="post" name="frmNewTrustOpeningDate" novalidate="">
+		@Html.AntiForgeryToken()
+		<input type="hidden" asp-for="ApplicationId"/>
+		<partial name="_HiddenFields"/>
+        
+		<div class="@(!ViewData.ModelState.IsValid ? "govuk-form-group--error" : "")">
+			<fieldset class="govuk-fieldset">
+				<div class="@(!ViewData.ModelState.IsValid ? "govuk-visually-hidden" : "")">
+					<partial name="_ValidationSummary" model="Model.ValidationErrorMessagesViewModel"/>
+				</div>
+				
+                // 3 big input boxes !!
+			</fieldset>
+		</div>        
+
+		<input type="submit" value="Save and continue" class="govuk-button govuk-!-margin-top-2 govuk-!-margin-bottom-8"/>
+	</form>
+</div>

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml
@@ -25,8 +25,34 @@
 				<div class="@(!ViewData.ModelState.IsValid ? "govuk-visually-hidden" : "")">
 					<partial name="_ValidationSummary" model="Model.ValidationErrorMessagesViewModel"/>
 				</div>
-				
-                // 3 big input boxes !!
+                
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Why are the schools forming the trust?</legend>
+                
+                // what is top big textbox?
+
+				<div class="govuk-form-group">
+                    <label for="FormTrustReasonVision" class="govuk-label">What vision and aspiration have the schools agreed for the trust?</label>
+                    <textarea asp-for="ReasonVision" id="ReasonVision"
+                              class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
+                </div>
+                
+                <div class="govuk-form-group">
+                    <label for="GeoAreas" class="govuk-label">What geographical areas and communities will the trust service?</label>
+                    <textarea asp-for="GeoAreas" id="GeoAreas"
+                              class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
+                </div>
+                
+                <div class="govuk-form-group">
+                    <label for="Freedom" class="govuk-label">How will the schools make the most of the freedoms that academies have?</label>
+                    <textarea asp-for="Freedom" id="Freedom"
+                              class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
+                </div>
+
+                <div class="govuk-form-group">
+                    <label for="ImproveTeaching" class="govuk-label">How will the schools work together to improve teaching and learning in the trust and potentially support other schools beyond the trust?</label>
+                    <textarea asp-for="ImproveTeaching" id="ImproveTeaching"
+                              class="govuk-textarea" cols="40" rows="5" maxlength="200"></textarea>
+                </div>
 			</fieldset>
 		</div>        
 

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml.cs
@@ -34,9 +34,9 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 
 		public ApplicationNewTrustReasonsModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService, 
 												IReferenceDataRetrievalService referenceDataRetrievalService, 
-												IConversionApplicationCreationService conversionApplicationCreationService, 
-												string nextStepPage) 
-			: base(conversionApplicationRetrievalService, referenceDataRetrievalService, conversionApplicationCreationService, nextStepPage)
+												IConversionApplicationCreationService conversionApplicationCreationService) 
+			: base(conversionApplicationRetrievalService, referenceDataRetrievalService, conversionApplicationCreationService, 
+				"ApplicationNewTrustReasonsSummary")
 		{
 		}
 

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml.cs
@@ -12,7 +12,9 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 
 		// MR:- VM props to capture data
 
-		// TODO:- top one ??
+		[BindProperty]
+		[Required(ErrorMessage = "You must provide details")]
+		public string ReasonForming { get; set; } = string.Empty;
 
 		[BindProperty]
 		[Required(ErrorMessage = "You must provide details")]
@@ -60,7 +62,7 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 		{
 			return new Dictionary<string, dynamic>
 			{
-				// TODO:- what is top one ??
+				{ nameof(NewTrust.FormTrustReasonForming), ReasonForming },
 				{ nameof(NewTrust.FormTrustReasonVision), ReasonVision },
 				{ nameof(NewTrust.FormTrustReasonGeoAreas), GeoAreas },
 				{ nameof(NewTrust.FormTrustReasonFreedom), Freedom },
@@ -73,12 +75,11 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 			if (conversionApplication != null && conversionApplication.FormTrustDetails != null)
 			{
 				TrustName = conversionApplication.FormTrustDetails.FormTrustProposedNameOfTrust;
-				// TODO:- what is top one ??
-				// ReasonVision = conversionApplication.FormTrustDetails.;
-				ReasonVision = conversionApplication.FormTrustDetails.FormTrustReasonVision;
-				GeoAreas = conversionApplication.FormTrustDetails.FormTrustReasonGeoAreas;
-				Freedom = conversionApplication.FormTrustDetails.FormTrustReasonFreedom;
-				ImproveTeaching = conversionApplication.FormTrustDetails.FormTrustReasonImproveTeaching;
+				ReasonForming = conversionApplication.FormTrustDetails.FormTrustReasonForming ?? string.Empty;
+				ReasonVision = conversionApplication.FormTrustDetails.FormTrustReasonVision ?? string.Empty;
+				GeoAreas = conversionApplication.FormTrustDetails.FormTrustReasonGeoAreas ?? string.Empty;
+				Freedom = conversionApplication.FormTrustDetails.FormTrustReasonFreedom ?? string.Empty;
+				ImproveTeaching = conversionApplication.FormTrustDetails.FormTrustReasonImproveTeaching ?? string.Empty;
 			}
 		}
 	}

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml.cs
@@ -1,6 +1,8 @@
-﻿using Dfe.Academies.External.Web.Models;
+﻿using System.ComponentModel.DataAnnotations;
+using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 {
@@ -9,6 +11,24 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 		public string TrustName { get; private set; } = string.Empty;
 
 		// MR:- VM props to capture data
+
+		// TODO:- top one ??
+
+		[BindProperty]
+		[Required(ErrorMessage = "You must provide details")]
+		public string ReasonVision { get; set; } = string.Empty;
+
+		[BindProperty]
+		[Required(ErrorMessage = "You must provide details")]
+		public string GeoAreas { get; set; } = string.Empty;
+
+		[BindProperty]
+		[Required(ErrorMessage = "You must provide details")]
+		public string Freedom { get; set; } = string.Empty;
+
+		[BindProperty]
+		[Required(ErrorMessage = "You must provide details")]
+		public string ImproveTeaching { get; set; } = string.Empty;
 
 		public ApplicationNewTrustReasonsModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService, 
 												IReferenceDataRetrievalService referenceDataRetrievalService, 
@@ -38,8 +58,14 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 
 		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
 		{
-			// TODO:-
-			throw new NotImplementedException();
+			return new Dictionary<string, dynamic>
+			{
+				// TODO:- what is top one ??
+				{ nameof(NewTrust.FormTrustReasonVision), ReasonVision },
+				{ nameof(NewTrust.FormTrustReasonGeoAreas), GeoAreas },
+				{ nameof(NewTrust.FormTrustReasonFreedom), Freedom },
+				{ nameof(NewTrust.FormTrustReasonImproveTeaching), ImproveTeaching },
+			};
 		}
 
 		public override void PopulateUiModel(ConversionApplication? conversionApplication)
@@ -47,10 +73,12 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 			if (conversionApplication != null && conversionApplication.FormTrustDetails != null)
 			{
 				TrustName = conversionApplication.FormTrustDetails.FormTrustProposedNameOfTrust;
-				// TODO:-
-				//OpeningDate = conversionApplication.FormTrustDetails.FormTrustOpeningDate.ToString();
-				//TrustApproverName = conversionApplication.FormTrustDetails.TrustApproverName;
-				//TrustApproverEmail = conversionApplication.FormTrustDetails.TrustApproverEmail;
+				// TODO:- what is top one ??
+				// ReasonVision = conversionApplication.FormTrustDetails.;
+				ReasonVision = conversionApplication.FormTrustDetails.FormTrustReasonVision;
+				GeoAreas = conversionApplication.FormTrustDetails.FormTrustReasonGeoAreas;
+				Freedom = conversionApplication.FormTrustDetails.FormTrustReasonFreedom;
+				ImproveTeaching = conversionApplication.FormTrustDetails.FormTrustReasonImproveTeaching;
 			}
 		}
 	}

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasons.cshtml.cs
@@ -1,0 +1,57 @@
+﻿using Dfe.Academies.External.Web.Models;
+using Dfe.Academies.External.Web.Pages.Base;
+using Dfe.Academies.External.Web.Services;
+
+namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
+{
+    public class ApplicationNewTrustReasonsModel : BaseTrustFamApplicationPageEditModel
+	{
+		public string TrustName { get; private set; } = string.Empty;
+
+		// MR:- VM props to capture data
+
+		public ApplicationNewTrustReasonsModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService, 
+												IReferenceDataRetrievalService referenceDataRetrievalService, 
+												IConversionApplicationCreationService conversionApplicationCreationService, 
+												string nextStepPage) 
+			: base(conversionApplicationRetrievalService, referenceDataRetrievalService, conversionApplicationCreationService, nextStepPage)
+		{
+		}
+
+		///<inheritdoc/>
+		public override void PopulateValidationMessages()
+		{
+			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override bool RunUiValidation()
+		{
+			if (!ModelState.IsValid)
+			{
+				PopulateValidationMessages();
+				return false;
+			}
+
+			return true;
+		}
+
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// TODO:-
+			throw new NotImplementedException();
+		}
+
+		public override void PopulateUiModel(ConversionApplication? conversionApplication)
+		{
+			if (conversionApplication != null && conversionApplication.FormTrustDetails != null)
+			{
+				TrustName = conversionApplication.FormTrustDetails.FormTrustProposedNameOfTrust;
+				// TODO:-
+				//OpeningDate = conversionApplication.FormTrustDetails.FormTrustOpeningDate.ToString();
+				//TrustApproverName = conversionApplication.FormTrustDetails.TrustApproverName;
+				//TrustApproverEmail = conversionApplication.FormTrustDetails.TrustApproverEmail;
+			}
+		}
+	}
+}

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasonsSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasonsSummary.cshtml
@@ -1,0 +1,24 @@
+﻿@page
+@model Dfe.Academies.External.Web.Pages.Trust.FormAMat.ApplicationNewTrustReasonsSummaryModel
+@{
+	ViewData["Title"] = "Apply to become an academy - Trust reasons summary";
+}
+
+@section BeforeMain
+{
+	<a asp-page="ApplicationNewTrustSummary" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">Back to application overview</a>
+}
+
+<div class="govuk-grid-column-full">
+	<span class="govuk-caption-l">
+		@Model.TrustName
+	</span>
+	<h1 class="govuk-heading-l">Reasons</h1>
+
+    <a asp-page="ApplicationNewTrustReasons" asp-route-appId="@Model.ApplicationId" class="govuk-link">Reasons</a>
+
+	@*    <p id="summaryTableDescription" class="govuk-body">Trust reasons summary</p>*@
+	<a asp-page="ApplicationNewTrustSummary" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
+</div>
+
+<partial name="_HiddenFields" />

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasonsSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasonsSummary.cshtml.cs
@@ -1,0 +1,49 @@
+﻿using Dfe.Academies.External.Web.Models;
+using Dfe.Academies.External.Web.Pages.Base;
+using Dfe.Academies.External.Web.Services;
+
+namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
+{
+    public class ApplicationNewTrustReasonsSummaryModel : BaseTrustFamApplicationSummaryPageModel
+	{
+		//// MR:- VM props to show data
+		// TODO:-
+		
+		public ApplicationNewTrustReasonsSummaryModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService, 
+												IReferenceDataRetrievalService referenceDataRetrievalService) 
+	        : base(conversionApplicationRetrievalService, referenceDataRetrievalService)
+        {
+        }
+
+        ///<inheritdoc/>
+        public override void PopulateValidationMessages()
+        {
+	        PopulateViewDataErrorsWithModelStateErrors();
+        }
+
+        ///<inheritdoc/>
+        public override bool RunUiValidation()
+        {
+	        // does not apply on this page
+	        return true;
+        }
+
+        ///<inheritdoc/>
+        public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+        {
+	        // does not apply on this page
+	        return new();
+        }
+
+        ///<inheritdoc/>
+		public override void PopulateUiModel(ConversionApplication? conversionApplication)
+        {
+	        if (conversionApplication != null && conversionApplication.FormTrustDetails != null)
+	        {
+		        TrustName = conversionApplication.FormTrustDetails.FormTrustProposedNameOfTrust;
+
+				// TODO:- setup VM
+	        }
+        }
+	}
+}


### PR DESCRIPTION
see ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/107019

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Build new page to capture FAM - Trust reasons for forming the trust (details) page

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. go into the app overview for a FAM application type
2. go into trust details / summary page
3. click 'reasons for forming a trust' link
4. click on reasons link (stub page)
5. you'll then see new page:- https://localhost:44350/trust/form-amat/application-new-trust-reasons?appId=7

## Prerequisites
n/a
