### PR TITLE
Only show submit button if application status = in progress

### DIFF
--- a/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml
+++ b/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml
@@ -191,7 +191,7 @@
 			@Html.AntiForgeryToken()
 			<input type="hidden" asp-for="ApplicationId"/>
 
-			@if (Model.UserHasSubmitApplicationRole && Model.ConversionStatus == Status.Completed)
+			@if (Model.UserHasSubmitApplicationRole && Model.ConversionStatus == Status.Completed && Model.ApplicationStatus == ApplicationStatus.InProgress)
 		    {
 			    <input type="submit" value="Submit application" class="govuk-button govuk-!-margin-top-6" />
 		    }


### PR DESCRIPTION
see ticket:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/114091?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Double application submission causes yellow screen of death. so, stop an application being submitted after it's been submitted!

## Steps to reproduce issue (if relevant)
1. Go to app overview as chair, with all details filled in, submit application
2. you can go back to  app overview as chair and still see submit button

## Steps to test this PR
1. Go to app overview as chair, with all details filled in, submit application
2. you can go back to  app overview as chair and you WON'T see submit button

## Prerequisites
n/a
