### PR TITLE
add missing class to mailto

### DIFF
--- a/Dfe.Academies.External.Web/Pages/ApplicationSubmitted.cshtml
+++ b/Dfe.Academies.External.Web/Pages/ApplicationSubmitted.cshtml
@@ -39,7 +39,7 @@
         <a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education" rel="noopener" target="_blank">contact the Department for Education</a>.
 	</p>
 	<p class="govuk-body-m">
-        If you have any questions or comments about this service, e-mail <a href="mailto:regionalservices.rg@education.gov.uk">regionalservices.rg@education.gov.uk</a>
+        If you have any questions or comments about this service, e-mail <a class="govuk-link" href="mailto:regionalservices.rg@education.gov.uk">regionalservices.rg@education.gov.uk</a>
 	</p>
 
 	<p class="govuk-body-m">


### PR DESCRIPTION
See last comment on:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/104227?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
mailto link on page not using correct CSS

## Steps to reproduce issue (if relevant)
1. go to application submitted page
2. mailto link not correct font / colour

## Steps to test this PR
1. go to application submitted page
2. mailto link correct font / colour

## Prerequisites
n/a
