### PR TITLE
113208 fam school overview page statuses mainly

### DIFF
--- a/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml
+++ b/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml
@@ -37,7 +37,7 @@
 		</thead>
 		<tbody class="govuk-table__body">
 		@*If no school selected - render button instead*@
-		@if (!Model.SchoolOrSchoolsApplyingToConvert.Any() && Model.ApplicationType != ApplicationTypes.FormAMat)
+		@if (!Model.SchoolOrSchoolsApplyingToConvert.Any() && Model.ApplicationType == ApplicationTypes.JoinAMat)
 		{
 			<tr class="govuk-table__row">
 				<td class="govuk-table__cell">
@@ -61,18 +61,22 @@
 								@school.SchoolName
 							</a>
 						</td>
-						<td class="govuk-table__cell">
-							<a asp-page="/school/ApplicationSelectSchool" aria-describedby="component-change" class="govuk-link"
-							   asp-route-appId="@Model.ApplicationId">
-								Change
-							</a>
+                            <td class="govuk-table__cell govuk-!-text-align-right">
+                            TODO:- calc overall school status 
 						</td>
 					</tr>
 				}
 				<tr class="govuk-table__row">
-					<td class="govuk-table__cell" colspan="2">
+					<td class="govuk-table__cell">
 						<a asp-page="school/ApplicationSelectSchool"
 						   asp-route-appId="@Model.ApplicationId" class="govuk-button govuk-button--secondary">Add a school</a>
+					</td>
+					<td class="govuk-table__cell">
+						@if (Model.SchoolOrSchoolsApplyingToConvert.Any())
+	                    {
+	                        <a asp-page="school/Remove"
+	                           asp-route-appId="@Model.ApplicationId" class="govuk-button govuk-button--secondary">Remove a school</a>                                
+	                    }
 					</td>
 				</tr>
 			}

--- a/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml.cs
@@ -155,8 +155,8 @@ namespace Dfe.Academies.External.Web.Pages
 				if (conversionApplication.ApplicationType == ApplicationTypes.FormAMat)
 				{
 					HeaderText = "All school and trust details must be given before this application can be submitted.";
-					TrustHeaderText = "The trust being formed";
-					SchoolHeaderText = "The schools applying to convert";
+					TrustHeaderText = "Give details of the trust";
+					SchoolHeaderText = "Give details of schools in the trust";
 				}
 				else // JAM
 				{

--- a/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolConversionKeyDetails.cshtml
@@ -58,7 +58,7 @@
 		<div class="govuk-!-margin-6"></div>
 	}
 
-    <a asp-page="SchoolOverview" asp-route-appId="@Model.ApplicationId" asp-route-urn="@Model.Urn"
+    <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" asp-route-urn="@Model.Urn"
 	   class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
 <input type="hidden" asp-for="Urn"/>

--- a/Dfe.Academies.External.Web/Pages/School/SchoolOverview.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolOverview.cshtml
@@ -1,6 +1,7 @@
 ﻿@page
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @using Dfe.Academies.External.Web.Extensions
+@using Dfe.Academies.External.Web.Enums
 @model SchoolOverviewModel
 @{
 	ViewData["Title"] = "Apply to become an academy - School Overview";
@@ -24,8 +25,18 @@
 	</p>
 
 	<partial name="_SchoolComponentsStatusPartial" model="Model.SchoolComponents"/>
+    
+	@if (!Model.UserHasSubmitApplicationRole && Model.DeclarationStatus == Status.Completed)
+	{
+		<div class="govuk-warning-text">
+			<span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+			<strong class="govuk-warning-text__text">
+				<span class="govuk-warning-text__assistive">Warning</span>
+				Only the school's chair of governors can submit this application.
+			</strong>
+		</div>
+	}
 
-        <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
+	<a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
 <input type="hidden" value="@Model.Urn"/>
-<partial name="_HiddenFields"/>

--- a/Dfe.Academies.External.Web/Pages/School/SchoolOverview.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/SchoolOverview.cshtml.cs
@@ -13,6 +13,21 @@ namespace Dfe.Academies.External.Web.Pages.School
 
 		public SchoolComponentsViewModel SchoolComponents { get; private set; } = new();
 
+		/// <summary>
+		/// Calculated within here ONLY dependent on whether all the components / sections have been completed !
+		/// </summary>
+		public Status ConversionStatus { get; private set; }
+
+		/// <summary>
+		/// ONLY whether declaration section has been completed!
+		/// </summary>
+		public Status DeclarationStatus { get; private set; }
+
+		/// <summary>
+		/// Always have a trust conversion status whether Join a MAT or form a MAT !!
+		/// </summary>
+		public Status TrustConversionStatus { get; private set; }
+
 		public SchoolOverviewModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService,
 									IReferenceDataRetrievalService referenceDataRetrievalService)
 			: base(conversionApplicationRetrievalService, referenceDataRetrievalService)
@@ -90,6 +105,8 @@ namespace Dfe.Academies.External.Web.Pages.School
 					{
 						Status = c.Status
 					}).ToList()
+
+				// TODO:- set statuses
 			};
 
 			SchoolComponents = componentsVm;


### PR DESCRIPTION
Some tweaks on app overview / school overview page for FAM journey. Ahead of estimation

NO changes to JAM journey

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Some tweaks on app overview / school overview page for FAM journey. Ahead of estimation

Implementing design layout on tickets:-
- 106396
- 112305
- 112306

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. go to app overview page where app type = FAM with school, you'll see a) additional status against school, b) remove school button added, c) school name link goes to school overview page and d) amended title text above schools & trust as per ticket
2. go to app overview page where app type = FAM without school. Just see add school button ONLY
3.
4.

## Prerequisites
n/a
