### PR TITLE
coded up CalculateFormAMatTrustStatus() for FAM app overview

### DIFF
--- a/Dfe.Academies.External.Web/Services/ConversionApplicationRetrievalService.cs
+++ b/Dfe.Academies.External.Web/Services/ConversionApplicationRetrievalService.cs
@@ -428,7 +428,7 @@ public sealed class ConversionApplicationRetrievalService : BaseService, IConver
 
 		return Status.NotStarted;
 	}
-
+	
 	///<inheritdoc/>
 	public Status CalculateJoinAMatTrustStatus(ConversionApplication? conversionApplication)
 	{
@@ -448,10 +448,34 @@ public sealed class ConversionApplicationRetrievalService : BaseService, IConver
 	///<inheritdoc/>
 	public Status CalculateFormAMatTrustStatus(ConversionApplication? conversionApplication)
 	{
-		// TODO:- agree logic !!
+		if (conversionApplication?.FormTrustDetails != null)
+		{
+			var applicationFormTrustDetails = conversionApplication.FormTrustDetails;
 
-		// consume below:-
-		// conversionApplication.FormATrust
+			bool nameOfTrustStatus = CalculateNameOfTheTrustSectionStatus(applicationFormTrustDetails) == Status.Completed;
+			bool openingDateStatus = CalculateOpeningDateSectionStatus(applicationFormTrustDetails) == Status.Completed;
+			bool trustReasonsStatus = CalculateReasonsForFormingTrustSectionStatus(applicationFormTrustDetails) == Status.Completed;
+			bool plansForGrowthStatus = CalculatePlansForGrowthSectionStatus(applicationFormTrustDetails) == Status.Completed;
+			bool improvementStatus = CalculateSchoolImprovementStrategyStatus(applicationFormTrustDetails) == Status.Completed;
+			bool governanceStatus = CalculateGovernanceStructureSectionStatus(conversionApplication) == Status.Completed;
+			bool keyPeopleStatus = CalculateKeyPeopleSectionStatus(applicationFormTrustDetails) == Status.Completed;
+
+			var boolList = new List<bool>
+			{
+				nameOfTrustStatus,
+				openingDateStatus,
+				trustReasonsStatus,
+				plansForGrowthStatus,
+				improvementStatus,
+				governanceStatus,
+				keyPeopleStatus
+			};
+
+			if (boolList.All(x => x))
+				return Status.Completed;
+
+			return boolList.All(x => !x) ? Status.NotStarted : Status.InProgress;
+		}
 
 		return Status.NotStarted;
 	}


### PR DESCRIPTION
See comments about trust status logic on:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/112305?McasTsid=26110

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
coded up CalculateFormAMatTrustStatus() for FAM app overview

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. go to app overview - application type = FAM
2. trust status now shows not started / InProgress / completed

## Prerequisites
n/a
