### PR TITLE
Bugfixed status on summary page, the details subheading not present, …

### DIFF
--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustGovernanceSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustGovernanceSummary.cshtml
@@ -16,7 +16,8 @@
 		@Model.TrustName
 	</span>
 	<h1 class="govuk-heading-l">Governance structure</h1>
-
+	<br/>
+	<h1 class="govuk-heading-m">Details</h1>
 	@*    <p id="summaryTableDescription" class="govuk-body">Trust opening date summary</p>*@
 	@foreach (var question in Model.ViewModel)
 	{

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustGovernanceSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustGovernanceSummary.cshtml.cs
@@ -48,24 +48,26 @@ namespace Dfe.Academies.External.Web.Pages.Trust.FormAMat
 			{
 				TrustName = conversionApplication.FormTrustDetails.FormTrustProposedNameOfTrust;
 
+				var result = _fileUploadService.GetFiles(FileUploadConstants.TopLevelFolderName, conversionApplication.ApplicationId.ToString(), conversionApplication.ApplicationReference, FileUploadConstants.JoinAMatTrustGovernanceFilePrefixFieldName).Result;
+				var files = result.Aggregate(string.Empty, (current, fileName) => current + (fileName + "\n"));
+
+				
 				ApplicationNewTrustGovernanceHeadingViewModel heading1 = new(ApplicationNewTrustGovernanceHeadingViewModel.Heading, // heading = 'Details'
 					"/Trust/FormAMat/ApplicationNewTrustGovernanceStructureDetails")
 				{
-					Status = !string.IsNullOrWhiteSpace(conversionApplication.FormTrustDetails.FormTrustReasonForming) ?
+					Status = result.Any() ?
 						SchoolConversionComponentStatus.Complete
 						: SchoolConversionComponentStatus.NotStarted
 				};
 
 				// TODO MR:- only upload doc, how to check?
 
-				var result = _fileUploadService.GetFiles(FileUploadConstants.TopLevelFolderName, conversionApplication.ApplicationId.ToString(), conversionApplication.ApplicationReference, FileUploadConstants.JoinAMatTrustGovernanceFilePrefixFieldName).Result;
-				var files = result.Aggregate(string.Empty, (current, fileName) => current + (fileName + "\n"));
-				
+
 				heading1.Sections.Add(new(
 					ApplicationNewTrustGovernanceSectionViewModel.StructureDocument,
 					result.Any() ?
 						files :
-						QuestionAndAnswerConstants.NoAnswer));
+						QuestionAndAnswerConstants.NoInfoAnswer));
 
 				var vm = new List<ApplicationNewTrustGovernanceHeadingViewModel> { heading1 };
 


### PR DESCRIPTION
…and the missing information text

<!--- Link to issue this PR resolves -->
Resolves #<1234>

## Type of change
<!--- Tick the appropriate checkbox -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
<!--- Tell us what should happen: -->
<!--- * If a new feature then briefly explain what has been added -->
<!--- * If a bug fix briefly explain what should be happening that isn't -->
Bugfixed status on summary page, the details subheading not present, and the missing information text
<!--- * If a breaking change then briefly explain what is changing -->

## Steps to reproduce issue (if relevant)
<!--- Steps to re-create bug before testing, only applies -->
<!--- if PR resolves a bug -->
1. Go to the FAM trust summary
2. Go to governance structure summary page
3. Has the "start section" button changed to "Change your answers"
4. Does the "Details" subheading appear?
5. When there are no files uploaded does it say "You have not entered any information"

## Steps to test this PR
<!--- Suggested steps reviewers need to take to test this PR -->
1.
2.
3.
4.

## Prerequisites
<!--- Put any SQL, scripts or software packages that are required to run -->
<!--- this branch on a local copy / in production -->
