### PR TITLE
113358 - Add remove a school selection screen

### DIFF
--- a/Dfe.Academies.External.Web.UnitTest/Pages/RemoveSchoolSelectionModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Pages/RemoveSchoolSelectionModelTests.cs
@@ -1,0 +1,63 @@
+﻿using AutoFixture;
+using Dfe.Academies.External.Web.Pages;
+using Dfe.Academies.External.Web.Services;
+using Dfe.Academies.External.Web.UnitTest.Factories;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace Dfe.Academies.External.Web.UnitTest.Pages;
+
+[Parallelizable(ParallelScope.All)]
+public class RemoveSchoolSelectionModelTests
+{
+	private static readonly Fixture Fixture = new();
+
+	/// <summary>
+	/// "draftConversionApplication" in temp storage
+	/// from previous step in the new application wizard
+	/// </summary>
+	/// <returns></returns>
+	[Test]
+	public async Task OnGetAsync___Valid___NullErrors()
+	{
+		// arrange
+		var draftConversionApplicationStorageKey = TempDataHelper.DraftConversionApplicationKey;
+		var mockConversionApplicationRetrievalService = new Mock<IConversionApplicationRetrievalService>();
+		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
+		int applicationId = Fixture.Create<int>();
+
+		var conversionApplication = ConversionApplicationTestDataFactory.BuildNewConversionApplicationWithChairRole();
+
+		// act
+		var pageModel = SetupRemoveSchoolSelectionModel(mockConversionApplicationRetrievalService.Object,
+			mockReferenceDataRetrievalService.Object);
+		TempDataHelper.StoreSerialisedValue(draftConversionApplicationStorageKey, pageModel.TempData, conversionApplication);
+
+		// act
+		await pageModel.OnGetAsync(applicationId);
+
+		// assert
+		Assert.That(pageModel.TempData["Errors"], Is.EqualTo(null));
+	}
+
+	private static RemoveSchoolSelectionModel SetupRemoveSchoolSelectionModel(
+		IConversionApplicationRetrievalService mockConversionApplicationRetrievalService,
+		IReferenceDataRetrievalService mockReferenceDataRetrievalService,
+		bool isAuthenticated = false)
+	{
+		(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
+
+		return new RemoveSchoolSelectionModel(mockConversionApplicationRetrievalService, mockReferenceDataRetrievalService)
+		{
+			PageContext = pageContext,
+			TempData = tempData,
+			Url = new UrlHelper(actionContext),
+			MetadataProvider = pageContext.ViewData.ModelMetadata
+		};
+	}
+}

--- a/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml
+++ b/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml
@@ -74,7 +74,7 @@
 					<td class="govuk-table__cell">
 						@if (Model.SchoolOrSchoolsApplyingToConvert.Any())
 	                    {
-	                        <a asp-page="school/Remove"
+		                    <a asp-page="RemoveSchoolSelection"
 	                           asp-route-appId="@Model.ApplicationId" class="govuk-button govuk-button--secondary">Remove a school</a>                                
 	                    }
 					</td>

--- a/Dfe.Academies.External.Web/Pages/RemoveSchoolSelection.cshtml
+++ b/Dfe.Academies.External.Web/Pages/RemoveSchoolSelection.cshtml
@@ -1,0 +1,33 @@
+﻿@page
+@model Dfe.Academies.External.Web.Pages.RemoveSchoolSelectionModel
+@{
+	ViewData["Title"] = "Apply to become an academy - Remove a school";
+}
+
+@section BeforeMain
+{
+    <a asp-page="ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-back-link">
+		Back
+	</a>
+}
+
+<div class="govuk-grid-column-two-thirds">
+    
+	<h1 class="govuk-heading-l">
+		Which school do you want to remove?
+	</h1>
+
+	<p class="govuk-caption-m">All information about the school will be lost, and you will need to provide it again if you re-add it later.</p>
+
+	<form method="post" name="frmAddContributor" novalidate="">
+		@Html.AntiForgeryToken()
+		<input type="hidden" asp-for="ApplicationId"/>
+        
+        //TODO MR:- radio of schools, might be a problem with school name?
+
+		<partial name="_HiddenFields"/>
+		<div class="govuk-button-group">
+			<input type="submit" value="Remove school" class="govuk-button"/>
+		</div>
+	</form>
+</div>

--- a/Dfe.Academies.External.Web/Pages/RemoveSchoolSelection.cshtml
+++ b/Dfe.Academies.External.Web/Pages/RemoveSchoolSelection.cshtml
@@ -23,9 +23,25 @@
 		@Html.AntiForgeryToken()
 		<input type="hidden" asp-for="ApplicationId"/>
         
-        //TODO MR:- radio of schools, might be a problem with school name?
+		<div class="govuk-form-group">
+			<div class="govuk-radios" data-module="govuk-radios">
+	            @foreach (var school in Model.ApplicationSchools)
+				{
+					<div class="govuk-radios__item">
+						<input type="radio"
+	                           asp-for="SelectedUrn"
+						       value="@school.Key"
+	                           id="RoleType@(school.Key)"
+						       class="govuk-radios__input"
+						       aria-expanded="False"/>
+						<label for="RoleType@(school.Key)" class="govuk-label govuk-radios__label">
+							@school.Value
+						</label>
+					</div>
+				}
+			</div>
+		</div>
 
-		<partial name="_HiddenFields"/>
 		<div class="govuk-button-group">
 			<input type="submit" value="Remove school" class="govuk-button"/>
 		</div>

--- a/Dfe.Academies.External.Web/Pages/RemoveSchoolSelection.cshtml
+++ b/Dfe.Academies.External.Web/Pages/RemoveSchoolSelection.cshtml
@@ -32,8 +32,7 @@
 	                           asp-for="SelectedUrn"
 						       value="@school.Key"
 	                           id="RoleType@(school.Key)"
-						       class="govuk-radios__input"
-						       aria-expanded="False"/>
+						       class="govuk-radios__input"/>
 						<label for="RoleType@(school.Key)" class="govuk-label govuk-radios__label">
 							@school.Value
 						</label>

--- a/Dfe.Academies.External.Web/Pages/RemoveSchoolSelection.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/RemoveSchoolSelection.cshtml.cs
@@ -1,0 +1,101 @@
+﻿using Dfe.Academies.External.Web.Models;
+using Dfe.Academies.External.Web.Pages.Base;
+using Dfe.Academies.External.Web.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dfe.Academies.External.Web.Pages
+{
+    public class RemoveSchoolSelectionModel : BasePageEditModel
+	{
+		[BindProperty]
+		public int ApplicationId { get; set; }
+
+		[BindProperty]
+		public int SelectedUrn { get; set; }
+		
+		private string NextStepPage { get; set; } = "/ApplicationRemoveSchool";
+
+		public RemoveSchoolSelectionModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService, 
+			IReferenceDataRetrievalService referenceDataRetrievalService) 
+			: base(conversionApplicationRetrievalService, referenceDataRetrievalService)
+		{
+		}
+
+		public async Task<ActionResult> OnGetAsync(int appId)
+		{
+			//// on load - grab draft application from temp
+			var draftConversionApplication = await LoadAndSetApplicationDetails(appId);
+
+			// check user access
+			var checkStatus = await CheckApplicationPermission(appId);
+
+			if (checkStatus is ForbidResult)
+			{
+				return RedirectToPage("ApplicationAccessException");
+			}
+
+			ApplicationId = appId;
+
+			PopulateUiModel(draftConversionApplication);
+
+			return Page();
+		}
+
+		public async Task<IActionResult> OnPostAsync()
+		{
+			//// grab draft application from temp= null
+			var draftConversionApplication =
+				TempDataHelper.GetSerialisedValue<ConversionApplication>(TempDataHelper.DraftConversionApplicationKey,
+					TempData) ?? new ConversionApplication();
+
+			if (!RunUiValidation())
+			{
+				return Page();
+			}
+
+			// update temp store for next step
+			TempDataHelper.StoreSerialisedValue(TempDataHelper.DraftConversionApplicationKey, TempData, draftConversionApplication);
+
+			return RedirectToPage(NextStepPage, new { appId = ApplicationId, urn = SelectedUrn });
+		}
+
+		///<inheritdoc/>
+		public override void PopulateValidationMessages()
+		{
+			PopulateViewDataErrorsWithModelStateErrors();
+		}
+
+		///<inheritdoc/>
+		public override bool RunUiValidation()
+		{
+			if (!ModelState.IsValid)
+			{
+				PopulateValidationMessages();
+				return false;
+			}
+
+			return true;
+		}
+
+		///<inheritdoc/>
+		public override Dictionary<string, dynamic> PopulateUpdateDictionary()
+		{
+			// does not apply on this page
+			return new();
+		}
+
+		public void PopulateUiModel(ConversionApplication? conversionApplication)
+		{
+			if (conversionApplication != null)
+			{
+				foreach (var school in conversionApplication.Schools)
+				{
+					// TODO MR:- pop a IList of schools with just below deets, or, an IDictionary
+
+					var x = school.URN;
+					var y = school.SchoolName;
+				}
+			}
+		}
+	}
+}

--- a/Dfe.Academies.External.Web/Pages/RemoveSchoolSelection.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/RemoveSchoolSelection.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using Dfe.Academies.External.Web.Models;
+﻿using System.ComponentModel.DataAnnotations;
+using Dfe.Academies.External.Web.Models;
 using Dfe.Academies.External.Web.Pages.Base;
 using Dfe.Academies.External.Web.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -11,14 +12,18 @@ namespace Dfe.Academies.External.Web.Pages
 		public int ApplicationId { get; set; }
 
 		[BindProperty]
+		[Required(ErrorMessage = "You must choose an option")]
 		public int SelectedUrn { get; set; }
 		
+		public Dictionary<int, string> ApplicationSchools { get; private set; }
+
 		private string NextStepPage { get; set; } = "/ApplicationRemoveSchool";
 
 		public RemoveSchoolSelectionModel(IConversionApplicationRetrievalService conversionApplicationRetrievalService, 
 			IReferenceDataRetrievalService referenceDataRetrievalService) 
 			: base(conversionApplicationRetrievalService, referenceDataRetrievalService)
 		{
+			ApplicationSchools = new Dictionary<int, string>();
 		}
 
 		public async Task<ActionResult> OnGetAsync(int appId)
@@ -50,6 +55,7 @@ namespace Dfe.Academies.External.Web.Pages
 
 			if (!RunUiValidation())
 			{
+				PopulateUiModel(draftConversionApplication); // otherwise lose app schools !
 				return Page();
 			}
 
@@ -90,10 +96,7 @@ namespace Dfe.Academies.External.Web.Pages
 			{
 				foreach (var school in conversionApplication.Schools)
 				{
-					// TODO MR:- pop a IList of schools with just below deets, or, an IDictionary
-
-					var x = school.URN;
-					var y = school.SchoolName;
+					ApplicationSchools.Add(school.URN, school.SchoolName);
 				}
 			}
 		}

--- a/Dfe.Academies.External.Web/Pages/Shared/_ErrorMessages.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Shared/_ErrorMessages.cshtml
@@ -23,7 +23,7 @@
 						@foreach (var error in errors)
 						{
 							<li>
-								<a href="#@error.Key">@string.Join(",", error.Value ?? Array.Empty<string>())</a>
+                                <span class="govuk-error-message">@string.Join(",", error.Value ?? Array.Empty<string>())</span>
 							</li>
 						}
 					</ul>


### PR DESCRIPTION
see:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/113358?McasTsid=26110

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Add remove a school selection screen

## Steps to reproduce issue (if relevant)
n/a

## Steps to test this PR
1. FAM - application overview - press remove school button
2. Ensure you go to new page
3. Press 'Remove school' button with no school selected, ensure get correct validation message
4. Press 'Remove school' button with school selected, ensure go to non existent page

## Prerequisites
n/a
