### PR TITLE
fix axe & wave critical & errors on summary pages

### DIFF
--- a/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustGovernanceSummaryModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Pages/Trust/FormAMat/ApplicationNewTrustGovernanceSummaryModelTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using Moq;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Microsoft.Extensions.Logging;
 
 namespace Dfe.Academies.External.Web.UnitTest.Pages.Trust.FormAMat;
 
@@ -31,12 +32,14 @@ internal sealed class ApplicationNewTrustGovernanceSummaryModelTests
 		var mockReferenceDataRetrievalService = new Mock<IReferenceDataRetrievalService>();
 		var mockFileUploadService = new Mock<IFileUploadService>();
 		int applicationId = Fixture.Create<int>();
+		var mockLogger = new Mock<ILogger<ApplicationNewTrustGovernanceSummaryModel>>();
 
 		var conversionApplication = ConversionApplicationTestDataFactory.BuildNewConversionApplicationWithChairRole();
 
 		// act
 		var pageModel = SetupApplicationNewTrustGovernanceSummaryModel(mockConversionApplicationRetrievalService.Object,
-			mockReferenceDataRetrievalService.Object, mockFileUploadService.Object);
+			mockReferenceDataRetrievalService.Object, mockFileUploadService.Object,
+			mockLogger.Object);
 		TempDataHelper.StoreSerialisedValue(draftConversionApplicationStorageKey, pageModel.TempData, conversionApplication);
 
 		// act
@@ -50,12 +53,13 @@ internal sealed class ApplicationNewTrustGovernanceSummaryModelTests
 		IConversionApplicationRetrievalService mockConversionApplicationRetrievalService,
 		IReferenceDataRetrievalService mockReferenceDataRetrievalService,
 		IFileUploadService mockFileUploadService,
+		ILogger<ApplicationNewTrustGovernanceSummaryModel> mockLogger,
 		bool isAuthenticated = false)
 	{
 		(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
 
 		return new ApplicationNewTrustGovernanceSummaryModel(mockConversionApplicationRetrievalService,
-			mockReferenceDataRetrievalService, mockFileUploadService)
+			mockReferenceDataRetrievalService, mockFileUploadService, mockLogger)
 		{
 			PageContext = pageContext,
 			TempData = tempData,

--- a/Dfe.Academies.External.Web.UnitTest/Pages/Trust/JoinAMat/ApplicationSchoolJoinAMatTrustSummaryModelTests.cs
+++ b/Dfe.Academies.External.Web.UnitTest/Pages/Trust/JoinAMat/ApplicationSchoolJoinAMatTrustSummaryModelTests.cs
@@ -8,6 +8,7 @@ using Moq;
 using NUnit.Framework;
 using System.Threading.Tasks;
 using Dfe.Academies.External.Web.Pages.Trust.JoinAMat;
+using Microsoft.Extensions.Logging;
 
 namespace Dfe.Academies.External.Web.UnitTest.Pages.Trust.JoinAMat;
 
@@ -29,12 +30,14 @@ internal sealed class ApplicationSchoolJoinAMatTrustSummaryModelTests
 		var mockFileUploadService = new Mock<IFileUploadService>();
 		int urn = 101934;
 		int applicationId = int.MaxValue;
+		var mockLogger = new Mock<ILogger<ApplicationSchoolJoinAMatTrustSummaryModel>>();
 
 		var conversionApplication = ConversionApplicationTestDataFactory.BuildNewConversionApplicationWithChairRole();
 
 		// act
 		var pageModel = SetupApplicationSchoolJoinAMatTrustSummaryModel(mockConversionApplicationRetrievalService.Object,
-			mockReferenceDataRetrievalService.Object, mockFileUploadService.Object);
+			mockReferenceDataRetrievalService.Object, mockFileUploadService.Object,
+			mockLogger.Object);
 		TempDataHelper.StoreSerialisedValue(draftConversionApplicationStorageKey, pageModel.TempData, conversionApplication);
 
 		// act
@@ -48,12 +51,13 @@ internal sealed class ApplicationSchoolJoinAMatTrustSummaryModelTests
 		IConversionApplicationRetrievalService mockConversionApplicationRetrievalService,
 		IReferenceDataRetrievalService mockReferenceDataRetrievalService,
 		IFileUploadService fileUploadService,
+		ILogger<ApplicationSchoolJoinAMatTrustSummaryModel> mockLogger,
 		bool isAuthenticated = false)
 	{
 		(PageContext pageContext, TempDataDictionary tempData, ActionContext actionContext) = PageContextFactory.PageContextBuilder(isAuthenticated);
 
 		return new ApplicationSchoolJoinAMatTrustSummaryModel(mockConversionApplicationRetrievalService,
-			mockReferenceDataRetrievalService, fileUploadService)
+			mockReferenceDataRetrievalService, fileUploadService, mockLogger)
 		{
 			PageContext = pageContext,
 			TempData = tempData,

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrantSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationPreOpeningSupportGrantSummary.cshtml
@@ -19,22 +19,15 @@
 		Pre-opening support grant
 	</h1>
 
-    @*    <p id="summaryTableDescription" class="govuk-body">Application Pre Opening Support Grant Summary</p>*@
 	@foreach (var question in Model.ViewModel)
     {
-        <table class="govuk-table" aria-describedby="summaryTableDescription">
-		    <thead>
-			    <tr>
-				    <th scope="col"></th>
-				    <th scope="col"></th>
-			    </tr>
-		    </thead>
+        <table class="govuk-table">
 		    <tbody class="govuk-table__body">
 			    <tr class="govuk-table__row">
 				    <td class="govuk-table__cell">
 					    @if (question.Status == SchoolConversionComponentStatus.NotStarted)
 					    {
-						    <a asp-page="@question.URI" aria-describedby="component-not started" class="govuk-button govuk-button--secondary"
+						    <a asp-page="@question.URI" class="govuk-button govuk-button--secondary"
 						       asp-route-appId="@Model.ApplicationId"
 						       asp-route-urn="@Model.Urn">
 							    Start section
@@ -42,7 +35,7 @@
 					    }
 					    else
 					    {
-						    <a asp-page="@question.URI" aria-describedby="component-change" class="govuk-link"
+						    <a asp-page="@question.URI" class="govuk-link"
 						       asp-route-appId="@Model.ApplicationId"
 						       asp-route-urn="@Model.Urn">
 							    Change your answers
@@ -63,4 +56,3 @@
     <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
 <input type="hidden" asp-for="Urn" />
-<partial name="_HiddenFields" />

--- a/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/ApplicationSchoolConsultationSummary.cshtml
@@ -19,22 +19,15 @@
 		Consultation
 	</h1>
 
-    @*    <p id="summaryTableDescription" class="govuk-body">Application School Consultation Summary</p>*@
 	@foreach (var question in Model.ViewModel)
 	{
-        <table class="govuk-table" aria-describedby="summaryTableDescription">
-			<thead>
-				<tr>
-					<th scope="col"></th>
-					<th scope="col"></th>
-				</tr>
-			</thead>
+        <table class="govuk-table">
 			<tbody class="govuk-table__body">
 				<tr class="govuk-table__row">
 					<td class="govuk-table__cell">
 						@if (question.Status == SchoolConversionComponentStatus.NotStarted)
 						{
-							<a asp-page="@question.URI" aria-describedby="component-not started" class="govuk-button govuk-button--secondary"
+							<a asp-page="@question.URI" class="govuk-button govuk-button--secondary"
 							   asp-route-appId="@Model.ApplicationId"
 							   asp-route-urn="@Model.Urn">
 								Start section
@@ -42,7 +35,7 @@
 						}
 						else
 						{
-							<a asp-page="@question.URI" aria-describedby="component-change" class="govuk-link"
+							<a asp-page="@question.URI" class="govuk-link"
 							   asp-route-appId="@Model.ApplicationId"
 							   asp-route-urn="@Model.Urn">
 								Change your answers
@@ -63,4 +56,3 @@
     <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
 <input type="hidden" asp-for="Urn" />
-<partial name="_HiddenFields" />

--- a/Dfe.Academies.External.Web/Pages/School/DeclarationSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/DeclarationSummary.cshtml
@@ -19,25 +19,18 @@
 		Declaration
 	</h1>
 	
-	@*    <p id="summaryTableDescription" class="govuk-body">Application School Declaration Summary</p>*@
 	@foreach (var heading in Model.ViewModel)
 	{
 		<h1 class="govuk-heading-m">
 			@heading.Title
 		</h1>
-        <table class="govuk-table" aria-describedby="summaryTableDescription">
-			<thead>
-				<tr>
-					<th scope="col"></th>
-					<th scope="col"></th>
-				</tr>
-			</thead>
+        <table class="govuk-table">
 			<tbody class="govuk-table__body">
 				<tr class="govuk-table__row">
 					<td class="govuk-table__cell">
 						@if (heading.Status == SchoolConversionComponentStatus.NotStarted)
 						{
-							<a asp-page="@heading.URI" aria-describedby="component-not started" class="govuk-button govuk-button--secondary"
+							<a asp-page="@heading.URI" class="govuk-button govuk-button--secondary"
 							   asp-route-appId="@Model.ApplicationId"
 							   asp-route-urn="@Model.Urn">
 								Start section
@@ -45,7 +38,7 @@
 						}
 						else
 						{
-							<a asp-page="@heading.URI" aria-describedby="component-change" class="govuk-link"
+							<a asp-page="@heading.URI" class="govuk-link"
 							   asp-route-appId="@Model.ApplicationId"
 							   asp-route-urn="@Model.Urn">
 								Change your answers
@@ -66,4 +59,3 @@
 	<a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
 <input type="hidden" asp-for="Urn" />
-<partial name="_HiddenFields" />

--- a/Dfe.Academies.External.Web/Pages/School/FinancesReview.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/FinancesReview.cshtml
@@ -19,25 +19,18 @@
 		Finances
 	</h1>
 
-    @*    <p id="summaryTableDescription" class="govuk-body">Application School Finances Summary</p>*@
 	@foreach (var heading in Model.ViewModel)
 	{
 		<h1 class="govuk-heading-m">
 			@heading.Title
 		</h1>
-        <table class="govuk-table" aria-describedby="summaryTableDescription">
-			<thead>
-				<tr>
-					<th scope="col"></th>
-					<th scope="col"></th>
-				</tr>
-			</thead>
+        <table class="govuk-table">
 			<tbody class="govuk-table__body">
 				<tr class="govuk-table__row">
 					<td class="govuk-table__cell">
 						@if (heading.Status == SchoolConversionComponentStatus.NotStarted)
 						{
-							<a asp-page="@heading.URI" aria-describedby="component-not started" class="govuk-button govuk-button--secondary"
+							<a asp-page="@heading.URI" class="govuk-button govuk-button--secondary"
 							   asp-route-appId="@Model.ApplicationId"
 							   asp-route-urn="@Model.Urn">
 								Start section
@@ -45,7 +38,7 @@
 						}
 						else
 						{
-							<a asp-page="@heading.URI" aria-describedby="component-change" class="govuk-link"
+							<a asp-page="@heading.URI" class="govuk-link"
 							   asp-route-appId="@Model.ApplicationId"
 							   asp-route-urn="@Model.Urn">
 								Change your answers
@@ -66,4 +59,3 @@
 	<a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
 <input type="hidden" asp-for="Urn" />
-<partial name="_HiddenFields" />

--- a/Dfe.Academies.External.Web/Pages/School/FurtherInformationSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/FurtherInformationSummary.cshtml
@@ -19,25 +19,18 @@
 		Further information
 	</h1>
 	
-	@*    <p id="summaryTableDescription" class="govuk-body">Application School Further Information Summary</p>*@
 	@foreach (var heading in Model.ViewModel)
 	{
 		<h1 class="govuk-heading-m">
 			@heading.Title
 		</h1>
-        <table class="govuk-table" aria-describedby="summaryTableDescription">
-			<thead>
-				<tr>
-					<th scope="col"></th>
-					<th scope="col"></th>
-				</tr>
-			</thead>
+        <table class="govuk-table">
 			<tbody class="govuk-table__body">
 				<tr class="govuk-table__row">
 					<td class="govuk-table__cell">
 						@if (heading.Status == SchoolConversionComponentStatus.NotStarted)
 						{
-							<a asp-page="@heading.URI" aria-describedby="component-not started" class="govuk-button govuk-button--secondary"
+							<a asp-page="@heading.URI" class="govuk-button govuk-button--secondary"
 							   asp-route-appId="@Model.ApplicationId"
 							   asp-route-urn="@Model.Urn">
 								Start section
@@ -45,7 +38,7 @@
 						}
 						else
 						{
-							<a asp-page="@heading.URI" aria-describedby="component-change" class="govuk-link"
+							<a asp-page="@heading.URI" class="govuk-link"
 							   asp-route-appId="@Model.ApplicationId"
 							   asp-route-urn="@Model.Urn">
 								Change your answers
@@ -66,4 +59,3 @@
 	<a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
 <input type="hidden" asp-for="Urn" />
-<partial name="_HiddenFields" />

--- a/Dfe.Academies.External.Web/Pages/School/PupilNumbersSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/PupilNumbersSummary.cshtml
@@ -19,22 +19,15 @@
 		Future pupil numbers
 	</h1>
 	
-	@*    <p id="summaryTableDescription" class="govuk-body">Application School Pupil numbers Summary</p>*@
 	@foreach (var question in Model.ViewModel)
 	{
-        <table class="govuk-table" aria-describedby="summaryTableDescription">
-			<thead>
-				<tr>
-					<th scope="col"></th>
-					<th scope="col"></th>
-				</tr>
-			</thead>
+        <table class="govuk-table">
 			<tbody class="govuk-table__body">
 				<tr class="govuk-table__row">
 					<td class="govuk-table__cell">
 						@if (question.Status == SchoolConversionComponentStatus.NotStarted)
 						{
-							<a asp-page="@question.URI" aria-describedby="component-not started" class="govuk-button govuk-button--secondary"
+							<a asp-page="@question.URI" class="govuk-button govuk-button--secondary"
 							   asp-route-appId="@Model.ApplicationId"
 							   asp-route-urn="@Model.Urn">
 								Start section
@@ -42,7 +35,7 @@
 						}
 						else
 						{
-							<a asp-page="@question.URI" aria-describedby="component-change" class="govuk-link"
+							<a asp-page="@question.URI" class="govuk-link"
 							   asp-route-appId="@Model.ApplicationId"
 							   asp-route-urn="@Model.Urn">
 								Change your answers
@@ -63,4 +56,3 @@
     <a asp-page="../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
 <input type="hidden" asp-for="Urn" />
-<partial name="_HiddenFields" />

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustGovernanceSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustGovernanceSummary.cshtml
@@ -18,29 +18,22 @@
 	<h1 class="govuk-heading-l">Governance structure</h1>
 	<br/>
 	<h1 class="govuk-heading-m">Details</h1>
-	@*    <p id="summaryTableDescription" class="govuk-body">Trust opening date summary</p>*@
 	@foreach (var question in Model.ViewModel)
 	{
-		<table class="govuk-table" aria-describedby="summaryTableDescription">
-			<thead>
-			<tr>
-				<th scope="col"></th>
-				<th scope="col"></th>
-			</tr>
-			</thead>
+		<table class="govuk-table">
 			<tbody class="govuk-table__body">
 			<tr class="govuk-table__row">
 				<td class="govuk-table__cell">
 					@if (question.Status == SchoolConversionComponentStatus.NotStarted)
 					{
-						<a asp-page="@question.URI" aria-describedby="component-not started" class="govuk-button govuk-button--secondary"
+						<a asp-page="@question.URI" class="govuk-button govuk-button--secondary"
 						   asp-route-appId="@Model.ApplicationId">
 							Start section
 						</a>
 					}
 					else
 					{
-						<a asp-page="@question.URI" aria-describedby="component-change" class="govuk-link"
+						<a asp-page="@question.URI" class="govuk-link"
 						   asp-route-appId="@Model.ApplicationId">
 							Change your answers
 						</a>

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustImprovementStrategySummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustImprovementStrategySummary.cshtml
@@ -17,32 +17,25 @@
 	</span>
     <h1 class="govuk-heading-l">School improvement strategy</h1>
 
-	@*    <p id="summaryTableDescription" class="govuk-body">Trust improvement strategy summary</p>*@
 	@foreach (var heading in Model.ViewModel)
 	{
 		<h1 class="govuk-heading-m">
 			@heading.Title
 		</h1>
-		<table class="govuk-table" aria-describedby="summaryTableDescription">
-			<thead>
-			<tr>
-				<th scope="col"></th>
-				<th scope="col"></th>
-			</tr>
-			</thead>
+		<table class="govuk-table">
 			<tbody class="govuk-table__body">
 			<tr class="govuk-table__row">
 				<td class="govuk-table__cell">
 					@if (heading.Status == SchoolConversionComponentStatus.NotStarted)
 					{
-						<a asp-page="@heading.URI" aria-describedby="component-not started" class="govuk-button govuk-button--secondary"
+						<a asp-page="@heading.URI" class="govuk-button govuk-button--secondary"
 						   asp-route-appId="@Model.ApplicationId">
 							Start section
 						</a>
 					}
 					else
 					{
-						<a asp-page="@heading.URI" aria-describedby="component-change" class="govuk-link"
+						<a asp-page="@heading.URI" class="govuk-link"
 						   asp-route-appId="@Model.ApplicationId">
 							Change your answers
 						</a>

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustOpeningDateSummary.cshtml
@@ -17,32 +17,25 @@
 	</span>
     <h1 class="govuk-heading-l">Opening date</h1>
 	<br/>
-@*    <p id="summaryTableDescription" class="govuk-body">Trust opening date summary</p>*@
 	@foreach (var heading in Model.ViewModel)
 	{
 		<h1 class="govuk-heading-m">
 			@heading.Title
 		</h1>
-		<table class="govuk-table" aria-describedby="summaryTableDescription">
-			<thead>
-				<tr>
-					<th scope="col"></th>
-					<th scope="col"></th>
-				</tr>
-			</thead>
+		<table class="govuk-table">
 			<tbody class="govuk-table__body">
 			<tr class="govuk-table__row">
 				<td class="govuk-table__cell">
 					@if (heading.Status == SchoolConversionComponentStatus.NotStarted)
 					{
-                            <a asp-page="@heading.URI" aria-describedby="component-not started" class="govuk-button govuk-button--secondary"
+                            <a asp-page="@heading.URI" class="govuk-button govuk-button--secondary"
 						   asp-route-appId="@Model.ApplicationId">
 							Start section
 						</a>
 					}
 					else
 					{
-                            <a asp-page="@heading.URI" aria-describedby="component-change" class="govuk-link"
+                            <a asp-page="@heading.URI" class="govuk-link"
 						   asp-route-appId="@Model.ApplicationId">
 							Change your answers
 						</a>

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasonsSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustReasonsSummary.cshtml
@@ -17,32 +17,25 @@
 	</span>
 	<h1 class="govuk-heading-l">Reasons for forming the trust</h1>
    
-@*    <p id="summaryTableDescription" class="govuk-body">Trust reasons summary</p>*@
 	@foreach (var heading in Model.ViewModel)
 	{
 		<h1 class="govuk-heading-m">
 			@heading.Title
 		</h1>
-		<table class="govuk-table" aria-describedby="summaryTableDescription">
-			<thead>
-			<tr>
-				<th scope="col"></th>
-				<th scope="col"></th>
-			</tr>
-			</thead>
+		<table class="govuk-table">
 			<tbody class="govuk-table__body">
 			<tr class="govuk-table__row">
 				<td class="govuk-table__cell">
                         @if (heading.Status == SchoolConversionComponentStatus.NotStarted)
 					{
-                            <a asp-page="@heading.URI" aria-describedby="component-not started" class="govuk-button govuk-button--secondary"
+                            <a asp-page="@heading.URI" class="govuk-button govuk-button--secondary"
 						   asp-route-appId="@Model.ApplicationId">
 							Start section
 						</a>
 					}
 					else
 					{
-                            <a asp-page="@heading.URI" aria-describedby="component-change" class="govuk-link"
+                            <a asp-page="@heading.URI" class="govuk-link"
 						   asp-route-appId="@Model.ApplicationId">
 							Change your answers
 						</a>

--- a/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/FormAMat/ApplicationNewTrustSummary.cshtml
@@ -22,18 +22,12 @@
     {
 	    <table class="govuk-table">
 		    <caption class="govuk-visually-hidden">Trust summary statuses</caption>
-		    <thead>
-		    <tr>
-			    <th scope="col"></th>
-			    <th scope="col"></th>
-		    </tr>
-		    </thead>
 		    <tbody class="govuk-table__body">
 		    @foreach (var component in Model.FormAMatTrustComponents.TrustComponents)
 		    {
 			    <tr class="govuk-table__row">
 				    <td class="govuk-table__cell">
-					    <a asp-page="@component.URI" aria-describedby="component-@(component.Name)-status" class="govuk-link"
+					    <a asp-page="@component.URI" class="govuk-link"
 					       asp-route-appId="@Model.ApplicationId">
 						    @component.Name
 					    </a>
@@ -49,9 +43,6 @@
 		    </tbody>
 	    </table>  
     }
-	
-	
+		
 	<a asp-page="../../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Return to your application</a>
 </div>
-
-<partial name="_HiddenFields" />

--- a/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/ApplicationSchoolJoinAMatTrustSummary.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Trust/JoinAMat/ApplicationSchoolJoinAMatTrustSummary.cshtml
@@ -18,25 +18,18 @@
         </span>
         <h1 class="govuk-heading-l">@Model.SelectedTrustName</h1>
         
-	    @*    <p id="summaryTableDescription" class="govuk-body">Application join a multi academy trust summary</p>*@
 	    @foreach (var heading in Model.ViewModel)
 		{
         <h1 class="govuk-heading-m">
             @heading.Title
         </h1>
-        <table class="govuk-table" aria-describedby="summaryTableDescription">
-		    <thead>
-		    <tr>
-			    <th scope="col"></th>
-			    <th scope="col"></th>
-		    </tr>
-		    </thead>
+        <table class="govuk-table">
 		    <tbody class="govuk-table__body">
 		    <tr class="govuk-table__row">
 			    <td class="govuk-table__cell">
 				    @if (heading.Status == SchoolConversionComponentStatus.NotStarted)
 				    {
-					    <a asp-page="@heading.URI" aria-describedby="component-not started" class="govuk-button govuk-button--secondary"
+					    <a asp-page="@heading.URI" class="govuk-button govuk-button--secondary"
 					       asp-route-appId="@Model.ApplicationId"
 					       asp-route-urn="@Model.Urn">
 						    Start section
@@ -44,7 +37,7 @@
 				    }
 				    else
 				    {
-					    <a asp-page="@heading.URI" aria-describedby="component-change" class="govuk-link"
+					    <a asp-page="@heading.URI" class="govuk-link"
 					       asp-route-appId="@Model.ApplicationId"
 					       asp-route-urn="@Model.Urn">
 						    Change your answers
@@ -64,5 +57,3 @@
 
     <a asp-page="../../ApplicationOverview" asp-route-appId="@Model.ApplicationId" class="govuk-button" data-module="govuk-button">Save and return to your application</a>
 </div>
-@*<input type="hidden" asp-for="Urn" />*@
-<partial name="_HiddenFields" />


### PR DESCRIPTION
see ticket:-
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/116006

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Axe & wave issues on following pages:-

- ApplicationPreOpeningSupportGrantSummary
- ApplicationSchoolConsultationSummary
- DeclarationSummary
- Finances summary
- FurtherInformationSummary
- LandAndBuildingsSummary
- PupilNumbersSummary
- ApplicationNewTrustGovernanceSummary
- ApplicationNewTrustImprovementStrategySummary
- ApplicationNewTrustOpeningDateSummary 
- ApplicationNewTrustReasonsSummary
- ApplicationSchoolJoinAMatTrustSummary 

## Steps to reproduce issue (if relevant)
Axe & wave issues on following pages:-

- ApplicationPreOpeningSupportGrantSummary
- ApplicationSchoolConsultationSummary
- DeclarationSummary
- Finances summary
- FurtherInformationSummary
- LandAndBuildingsSummary
- PupilNumbersSummary
- ApplicationNewTrustGovernanceSummary
- ApplicationNewTrustImprovementStrategySummary
- ApplicationNewTrustOpeningDateSummary 
- ApplicationNewTrustReasonsSummary
- ApplicationSchoolJoinAMatTrustSummary 

## Steps to test this PR
No Axe & wave issues on following pages:-

- ApplicationPreOpeningSupportGrantSummary
- ApplicationSchoolConsultationSummary
- DeclarationSummary
- Finances summary
- FurtherInformationSummary
- LandAndBuildingsSummary
- PupilNumbersSummary
- ApplicationNewTrustGovernanceSummary
- ApplicationNewTrustImprovementStrategySummary
- ApplicationNewTrustOpeningDateSummary 
- ApplicationNewTrustReasonsSummary
- ApplicationSchoolJoinAMatTrustSummary 

## Prerequisites
n/a
