### PR TITLE
114296 - add email validation where it's missing

### DIFF
--- a/Dfe.Academies.External.Web/ViewModels/ApplicationSchoolContactsViewModel.cs
+++ b/Dfe.Academies.External.Web/ViewModels/ApplicationSchoolContactsViewModel.cs
@@ -51,6 +51,7 @@ public sealed class ApplicationSchoolContactsViewModel
 
 	public string? MainContactOtherName { get; set; }
 
+	[EmailAddress(ErrorMessage = "Other contact email is not a valid e-mail address")]
 	public string? MainContactOtherEmail { get; set; }
 
 	public string? MainContactOtherTelephone { get; set; }
@@ -63,5 +64,7 @@ public sealed class ApplicationSchoolContactsViewModel
 	// TODO:- no validation on ticket for below?
 
 	public string? ApproverContactName { get; set; }
+
+	[EmailAddress(ErrorMessage = "Approver email is not a valid e-mail address")]
 	public string? ApproverContactEmail { get; set; }
 }


### PR DESCRIPTION
see tickets:-
https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/114296?McasTsid=26110

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
Everywhere in the app where an email address is input there should be validation for a valid email address

## Steps to reproduce issue (if relevant)
can enter 'potato' into School main contacts - head email address
can enter 'potato' into School main contacts - chair email address
can enter 'potato' into School main contacts - other email address
can enter 'potato' into School main contacts - approver email address

## Steps to test this PR
can't enter 'potato' into School main contacts - head email address
can't enter 'potato' into School main contacts - chair email address
can't enter 'potato' into School main contacts - other email address
can't enter 'potato' into School main contacts - approver email address

## Prerequisites
n/a
