### PR TITLE
Refactor GitHub workflow outputs

### DIFF
--- a/.github/workflows/cd-development.yml
+++ b/.github/workflows/cd-development.yml
@@ -30,8 +30,8 @@ jobs:
             VERSION=sha-${GITHUB_SHA}
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
           fi
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=deploy-version::${VERSION}
+          echo "tags::${TAGS}" >> $GITHUB_OUTPUT
+          echo "deploy-version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Push image
         uses: docker/build-push-action@v3


### PR DESCRIPTION
* The set-output command is depreciated. This refactors the workflows to output them into the GITHUB_OUTPUT environment variable instead.
* Warning: The \`set-output\` command is deprecated and will be disabled soon.