### PR TITLE
Add image build stage for Test/PreProd env

### DIFF
--- a/.github/workflows/build-and-push-image-test.yml
+++ b/.github/workflows/build-and-push-image-test.yml
@@ -1,0 +1,54 @@
+name: Continuous delivery / Test
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  set-test-release-version:
+    name: Set Test Release Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release-version.outputs.version }}
+    steps:
+      - id: release-version
+        run: echo "version=pre-release" >> $GITHUB_OUTPUT
+
+  build-and-push-image-test:
+    name: Build and push image test
+    runs-on: ubuntu-latest
+    needs: set-test-release-version
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.set-test-release-version.outputs.version }}
+
+      - name: Azure Container Registry login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.TEST_AZURE_ACR_CLIENTID }}
+          password: ${{ secrets.TEST_AZURE_ACR_SECRET }}
+          registry: ${{ secrets.TEST_ACR_URL }}
+
+      - name: Prepare tags
+        id: prepare-tags
+        run: |
+          DOCKER_IMAGE=${{ secrets.TEST_ACR_URL }}/a2bext-app
+          VERSION=latest
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION=sha-${GITHUB_SHA}
+            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${{ needs.set-test-release-version.outputs.version }}"
+          fi
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "deploy-version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Push image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.prepare-tags.outputs.tags }}


### PR DESCRIPTION
This pull request adds an image build and push workflow for the new Test environment in CIP. The image build will use the source code checked out to the GitHub tag `pre-release`. 