### PR TITLE
125932 fam application submission failure

### DIFF
--- a/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
+++ b/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
@@ -440,7 +440,7 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 		var command = new SubmitApplicationCommand(applicationId);
 
 		string apiurl = $"{_httpClient.BaseAddress}application/{applicationId}/submit?api-version=V1";
-		// expected object is not used, so deserialization to a generic object is sufficient
+		// expected object is not used, so deserialization to generic object is sufficient
 		await _resilientRequestProvider.PostAsync<Object, SubmitApplicationCommand>(apiurl, command);
 	}
 

--- a/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
+++ b/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
@@ -440,7 +440,7 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 		var command = new SubmitApplicationCommand(applicationId);
 
 		string apiurl = $"{_httpClient.BaseAddress}application/{applicationId}/submit?api-version=V1";
-		// expected object not used, so deserialization to a generic object is sufficient
+		// expected object is not used, so deserialization to a generic object is sufficient
 		await _resilientRequestProvider.PostAsync<Object, SubmitApplicationCommand>(apiurl, command);
 	}
 

--- a/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
+++ b/Dfe.Academies.External.Web/Services/ConversionApplicationCreationService.cs
@@ -440,7 +440,8 @@ public sealed class ConversionApplicationCreationService : BaseService, IConvers
 		var command = new SubmitApplicationCommand(applicationId);
 
 		string apiurl = $"{_httpClient.BaseAddress}application/{applicationId}/submit?api-version=V1";
-		await _resilientRequestProvider.PostAsync<ConversionApplication, SubmitApplicationCommand>(apiurl, command);
+		// expected object not used, so deserialization to a generic object is sufficient
+		await _resilientRequestProvider.PostAsync<Object, SubmitApplicationCommand>(apiurl, command);
 	}
 
 	public async Task CreateKeyPerson(int applicationId, NewTrustKeyPerson person)


### PR DESCRIPTION
the SubmitApplication in the ConversionApplicationCreationService has been changes to accept/deserialise a generic "Object" response.

the API ATM is returning a list of schools

We do not use the response for anything at the moment so deserialising to an "Object" is fine