### PR TITLE
Switched theme colour to match gov.uk patterns

### DIFF
--- a/Dfe.Academies.External.Web/Pages/Shared/_Layout.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Shared/_Layout.cshtml
@@ -30,7 +30,7 @@
 	<meta charset="utf-8">
 	<title>@ViewData["Title"] &ndash; Apply to become an academy</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-	<meta name="theme-color" content="blue"/>
+	<meta name="theme-color" content="#0b0c0c">
 
 	<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 


### PR DESCRIPTION
## Type of change
<!--- Tick the appropriate checkbox -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Steps to reproduce issue (if relevant)
When scrolling up or down past the end of the viewport in Safari on macOS you can see the theme color meta tag is applied which causes a jarring experience for the user.

<img width="1645" alt="Screenshot 2023-04-06 at 10 33 55" src="https://user-images.githubusercontent.com/3853061/230337423-d309f84e-58f2-4967-b328-f801c57b0176.png">

I've changed the value to one that gov.uk sites use which should match the header banner background colour
