### PR TITLE
Correctly set the Host header when the app is behind multiple proxies

### DIFF
--- a/Dfe.Academies.External.Web/Program.cs
+++ b/Dfe.Academies.External.Web/Program.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Notify.Client;
@@ -67,6 +68,16 @@ builder.Services
 		options.Filters.Add(new MaintenancePageFilter(configuration));
 	})
 	.AddSessionStateTempDataProvider();
+
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+	{
+		options.ForwardedHeaders =
+			ForwardedHeaders.XForwardedFor |
+			ForwardedHeaders.XForwardedHost |
+			ForwardedHeaders.XForwardedProto;
+
+		options.ForwardLimit = 2;  //Limit number of proxy hops trusted
+	});
 
 builder.Services.AddAuthentication(options =>
 	{


### PR DESCRIPTION
If we set the environment variable `ASPNETCORE_FORWARDEDHEADERS_ENABLED` to true the framework will insert the `ForwardedHeaders` middleware automatically for us.

The default aspnet behaviour for the `ForwardedHeaders` middleware is to assume that the app may sit behind a maximum of *1* Proxy at any time. 

>Forwarded Headers Middleware [default settings](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-6.0#forwarded-headers-middleware-options) can be configured. For the default settings:
>
>- There is only one proxy between the app and the source of the requests.
>- The forwarded headers are named [X-Forwarded-For](https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Forwarded-For) and [X-Forwarded-Proto](https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Forwarded-Proto).

This can be seen when trying to redirect users to the OIDC login URL when the app sits behind a single Proxy (Azure Front Door CDN). In this scenario, the default functionality of the middleware is sufficient and aspnet correctly uses the CDN URL/primary domain name as the `Host` header, which is also then sent through to the OIDC login URL as part of the `redirect_uri` parameter.

If the app is then placed behind a 2nd proxy (such as a Web Application Firewall), the middleware will incorrectly use the 2nd proxy's `X-Forwarded-For` header and disregard the 1st proxy's original header. This can be evidenced by visiting the OIDC login URL via the app, and seeing the WAF URL in the `redirect_uri` parameter.

By adjusting the configuration of the middleware, we can ensure the `X-Forwarded-Host` header is correctly inherited from the top of the request chain. This is set using the `options.ForwardLimit = 2;` option. Where `2` represents the maximum number of proxies in the chain.

Once this configuration is set, aspnet correctly sets the `Host` header to the 2nd-most value in the `X-Forwarded-Host` header if it is set, falling back to the 1st if there is only one value, or using the default `Host` if the header has no value at all.

This has been tested in a Docker container. I have included some debug output below where I have outputted both the Request headers, the HttpContext that aspnet serves up, and a test `curl` command I used. 

**Curl**
```
GET /debug HTTP/1.1
Host: localhost
X-Forwarded-Host: foo.dev, smart.dev, lala.local
X-Forwarded-Proto: https
```

**HttpContext**
```
HttpContext.Request.Scheme: https
HttpContext.Request.Host: smart.dev
```

**Raw Request**
```
X-Forwarded-Host :: foo.dev
X-Original-Host :: localhost
X-Original-Proto :: http
```

When accessing the OIDC login URL the request url looks like this:

```
GET https://[...]/?redirect_uri=https://smart.dev/[...]
```

This change will mean we no longer need to hardcode the Redirect Uri property for the OIDC request with `SignIn:RedirectUri` as it will now be dynamic based on the proxy `X-Forwarded-Host` header.
