### PR TITLE
Update test workflows to use secrets instead of vars

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -143,8 +143,8 @@ jobs:
         
         - name: Run cypress
           env:
-            URL: ${{ vars.URL }}
-            LOGIN_USERNAME: ${{ vars.LOGIN_USERNAME }}
+            URL: ${{ secrets.URL }}
+            LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
             LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
           run: npm run cy:run
         

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Run tests with scanner
         env:
           HTTP_PROXY: http://zap:8080
-          LOGIN_USERNAME: ${{ vars.LOGIN_USERNAME }}
+          LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
           LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
           NO_PROXY: "google-analytics.com,googletagmanager.com,microsoftonline.com,gvt1.com"
-          URL: ${{ vars.URL }}
+          URL: ${{ secrets.URL }}
           ZAP_API_KEY: ${{ secrets.ZAP_API_KEY }}
         run: |
           docker-compose -f Dfe.Academies.External.Web/CypressTests/docker-compose.yml up --exit-code-from cypress


### PR DESCRIPTION
Changes any instance of using `vars` to `secrets` for Cypress tests workflows