### PR TITLE
Feature/fixing cd action failing

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          secrets: github_token=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ${{ secrets.ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.branch }}
             ${{ secrets.ACR_URL }}/${{ env.DOCKER_IMAGE }}:${{ needs.set-env.outputs.release }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,8 @@ COPY ./Dfe.Academies.External.Web/ ./Dfe.Academies.External.Web/
 
 RUN --mount=type=secret,id=github_token dotnet nuget add source --username USERNAME --password $(cat /run/secrets/github_token) --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"
 RUN dotnet restore Dfe.Academies.External.Web
-RUN dotnet build Dfe.Academies.External.Web
-
-RUN dotnet publish Dfe.Academies.External.Web -c Release -o /app
+RUN dotnet build Dfe.Academies.External.Web --no-restore
+RUN dotnet publish Dfe.Academies.External.Web -c Release -o /app --no-restore
 
 COPY ./script/web-docker-entrypoint.sh /app/docker-entrypoint.sh
 


### PR DESCRIPTION
Change to build and deploy so that secret can be passed in, and used by nuget add package source.