### PR TITLE
Removing unnecessary Invite Contributor textcheck after completing Tr…

### DIFF
--- a/Dfe.Academies.External.Web/CypressTests/cypress/support/commands.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/support/commands.ts
@@ -567,10 +567,6 @@ Cypress.Commands.add('yourApplicationNotStartedButTrustSectionCompleteElementsVi
     cy.get(`a[href="/trust/join-amat/application-school-join-amat-trust-summary?appId=${globalApplicationId}"]`).contains('Trust details')
     cy.get('strong[class="govuk-tag app-task-list__tag"]').contains('Completed')
 
-
-
-    cy.get('h2[class="govuk-heading-l"]').contains('Contributors')
-    cy.get('p').eq(4).contains('You can invite or remove contributors to this form. If you are not the chair of the school\'s governing body, you must add them so that they can submit this application.')
 })
 
 Cypress.Commands.add('aboutTheConversionNotStartedElementsVisible', ():void => {

--- a/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml
+++ b/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml
@@ -193,7 +193,7 @@
 
 	@if (Model.HasSchool)
 	{
-		<p class="govuk-body">You can <a asp-page="AddAContributor" asp-route-appId="@Model.ApplicationId" class="govuk-link">invite or remove contributors to this form</a>. If you are not the chair of the schools's governing body, you must add them so that they can submit this application.</p>
+		<p class="govuk-body">You can <a asp-page="AddAContributor" asp-route-appId="@Model.ApplicationId" class="govuk-link">invite or remove contributors to this form</a>. If you are not the chair of the school's governing body, you must add them so that they can submit this application.</p>
 	}
 	else
 	{

--- a/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml
+++ b/Dfe.Academies.External.Web/Pages/ApplicationOverview.cshtml
@@ -193,7 +193,7 @@
 
 	@if (Model.HasSchool)
 	{
-		<p class="govuk-body">You can <a asp-page="AddAContributor" asp-route-appId="@Model.ApplicationId" class="govuk-link">invite other people to help you complete this form</a>. If you are not the chair of the schools's governing body, you must add them so that they can submit this application.</p>
+		<p class="govuk-body">You can <a asp-page="AddAContributor" asp-route-appId="@Model.ApplicationId" class="govuk-link">invite or remove contributors to this form</a>. If you are not the chair of the schools's governing body, you must add them so that they can submit this application.</p>
 	}
 	else
 	{


### PR DESCRIPTION
Hey Dan R,
Removing unnecessary check for Invite a contributor text after completing trust section.

Please can you approve this?

Apologies, Just noticed that the text on the Your application overview page states "schools's governing body" instead of "school's governing body"

Many thanks


