### PR TITLE
Fix zap script

### DIFF
--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -48,8 +48,6 @@ jobs:
         run: docker pull softwaresecurityproject/zap-stable:latest && mkdir -p ~/ci/cache/docker/softwaresecurityproject && docker image save softwaresecurityproject/zap-stable:latest --output ~/ci/cache/docker/softwaresecurityproject/zap-stable-${{ env.ZAP_VERSION }}.tar
 
       - name: Start ZAP container
-        env:
-          ZAP_PORT: 9876
         run: docker run --name zap_container --rm -d -v ${{ github.workspace }}/zapoutput/:/zap/wrk:rw -u zap -p ${{ env.ZAP_PORT }}:${{ env.ZAP_PORT }} -i softwaresecurityproject/zap-stable zap.sh -daemon -port ${{ env.ZAP_PORT }} -host 0.0.0.0 -config api.key=${{ secrets.ZAP_API_KEY }} -config api.addrs.addr.name=.* -config api.addrs.addr.regex=true -config network.localServers.mainProxy.alpn.enabled=false -config network.localServers.mainProxy.address=0.0.0.0
 
       - name: Set up NodeJS
@@ -62,15 +60,16 @@ jobs:
 
       - name: Run Cypress tests through scanner
         env:
-          HTTP_PROXY: http://${{ env.ZAP_ADDRESS }}:${{ env.ZAP_PORT }}
+          HTTP_PROXY: "http://${{ env.ZAP_ADDRESS }}:${{ env.ZAP_PORT }}"
           NO_PROXY: "google-analytics.com,googletagmanager.com,microsoftonline.com,gvt1.com"
           LOGIN_USERNAME: ${{ secrets.LOGIN_USERNAME }}
           LOGIN_PASSWORD: ${{ secrets.LOGIN_PASSWORD }}
           URL: ${{ secrets.URL }}
+          ZAP: true,
           ZAP_API_KEY: ${{ secrets.ZAP_API_KEY }}
           ZAP_ADDRESS: ${{ env.ZAP_ADDRESS }}
           ZAP_PORT: ${{ env.ZAP_PORT }}
-        run: npm run zap
+        run: npm run cy:run
 
       - name: Get git sha
         if: '!cancelled()'

--- a/Dfe.Academies.External.Web/CypressTests/cypress.config.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress.config.ts
@@ -24,7 +24,7 @@ module.exports = defineConfig({
      });
 
      on('after:run', async () => {
-      if(process.env.zap) {
+      if(process.env.ZAP) {
         await generateZapReport()
       }
      })

--- a/Dfe.Academies.External.Web/CypressTests/cypress/plugins/generateZapReport.js
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/plugins/generateZapReport.js
@@ -3,11 +3,14 @@ const fs = require('fs')
 
 module.exports = {
     generateZapReport: async () => {
+
+      console.log(`Generating ZAP report`)
+
       const zapOptions = {
-        apiKey: process.env.zapApiKey,
+        apiKey: process.env.ZAP_API_KEY,
         proxy: {
-          host: process.env.zapAddress,
-          port: process.env.zapPort
+          host: process.env.ZAP_ADDRESS,
+          port: process.env.ZAP_PORT
         }
       }
       const zaproxy = new ZapClient(zapOptions)

--- a/Dfe.Academies.External.Web/CypressTests/package.json
+++ b/Dfe.Academies.External.Web/CypressTests/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "cy:open": "cypress open",
     "cy:run": "cypress run --env url=$URL --env username=$LOGIN_USERNAME --env password=$LOGIN_PASSWORD",
-    "zap": "cypress run --env url=$url,username=$LOGIN_USERNAME,password=$LOGIN_PASSWORD,zap=true,zapAddress=$ZAP_ADDRESS,zapPort=$ZAP_PORT,zapApiKey=$ZAP_API_KEY",
     "lint": "eslint . --ext .js,.cy.js,.jsx,.ts.tsx"
   },
   "keywords": [


### PR DESCRIPTION
Fixes ZAP workflow not generating a report after test run.

Uses env vars rather than cypress vars to configure zap proxy

[Example run](https://github.com/DFE-Digital/Dfe.Academies.External/actions/runs/5819811892/job/15778948575)