### PR TITLE
Removed duplicate stylesheet reference

### DIFF
--- a/Dfe.Academies.External.Web/Pages/Shared/_Layout.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Shared/_Layout.cshtml
@@ -118,6 +118,5 @@
     @await RenderSectionAsync("scripts", required: false)
 
 <script src="~/assets/accessible-autocomplete.min.js"></script>
-<link rel="stylesheet" href="~/assets/component_guide/application-03e500f7e50f4bb8a952a029fffb091c8da3f5b9a6460086bf5d1d3464734232.css"/>
 </body>
 </html>


### PR DESCRIPTION
<!--- Link to issue this PR resolves -->
Resolves #513 

## Type of change
<!--- Tick the appropriate checkbox -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
The app should load a page without any font assets reporting 404 status codes
<!--- Tell us what should happen: -->
<!--- * If a new feature then briefly explain what has been added -->
<!--- * If a bug fix briefly explain what should be happening that isn't -->
<!--- * If a breaking change then briefly explain what is changing -->

## Steps to reproduce issue (if relevant)
<!--- Steps to re-create bug before testing, only applies -->
<!--- if PR resolves a bug -->
1. Load Dev Tools / Inspector on a Browser
2. Make a request to the homepage
3. Note a number of 404s to Font assets

## Steps to test this PR
<!--- Suggested steps reviewers need to take to test this PR -->
1. Load Dev Tools / Inspector on a Browser
2. Make a request to the homepage
3. Confirm all the CSS assets are loading as expected 
4. Confirm there has been no visual regression
5. Confirm that there are no 404s to Font assets 

## Prerequisites
<!--- Put any SQL, scripts or software packages that are required to run -->
<!--- this branch on a local copy / in production -->
N/A