### PR TITLE
Add Cypress User-agent to config

### DIFF
--- a/Dfe.Academies.External.Web/CypressTests/cypress.config.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     LOGIN_USERNAME: process.env.LOGIN_USERNAME,
     LOGIN_PASSWORD: process.env.LOGIN_PASSWORD,
   },
+	userAgent: 'DfEAcademiesExternal/1.0 Cypress',
   e2e: {
     supportFile: 'cypress/support/e2e.ts',
     specPattern: 'cypress/e2e',


### PR DESCRIPTION
Adds a User-Agent header to Cypress' config to mitigate Azure's bot traffic rules