### PR TITLE
Disable CDN origin health probe

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -167,6 +167,7 @@ No resources.
 | <a name="input_dns_txt_records"></a> [dns\_txt\_records](#input\_dns\_txt\_records) | DNS TXT records to add to the DNS Zone | <pre>map(<br>    object({<br>      ttl : optional(number, 300),<br>      records : list(string)<br>    })<br>  )</pre> | n/a | yes |
 | <a name="input_dns_zone_domain_name"></a> [dns\_zone\_domain\_name](#input\_dns\_zone\_domain\_name) | DNS zone domain name. If created, records will automatically be created to point to the CDN. | `string` | n/a | yes |
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Enable Azure CDN Front Door. This will use the Container Apps endpoint as the origin. | `bool` | n/a | yes |
+| <a name="input_enable_cdn_frontdoor_health_probe"></a> [enable\_cdn\_frontdoor\_health\_probe](#input\_enable\_cdn\_frontdoor\_health\_probe) | Enable CDN Front Door health probe | `bool` | `false` | no |
 | <a name="input_enable_container_app_blob_storage"></a> [enable\_container\_app\_blob\_storage](#input\_enable\_container\_app\_blob\_storage) | Create an Azure Storage Account and Storage Container to be accessed by the Container App | `bool` | n/a | yes |
 | <a name="input_enable_container_health_probe"></a> [enable\_container\_health\_probe](#input\_enable\_container\_health\_probe) | Enable liveness probes for the Container | `bool` | `true` | no |
 | <a name="input_enable_container_registry"></a> [enable\_container\_registry](#input\_enable\_container\_registry) | Set to true to create a container registry | `bool` | n/a | yes |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -42,6 +42,7 @@ module "azure_container_apps_hosting" {
   cdn_frontdoor_origin_host_header_override   = local.cdn_frontdoor_origin_host_header_override
   restrict_container_apps_to_cdn_inbound_only = local.restrict_container_apps_to_cdn_inbound_only
   container_apps_allow_ips_inbound            = local.container_apps_allow_ips_inbound
+  enable_cdn_frontdoor_health_probe           = local.enable_cdn_frontdoor_health_probe
 
   enable_monitoring             = local.enable_monitoring
   monitor_email_receivers       = local.monitor_email_receivers

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -32,6 +32,7 @@ locals {
   cdn_frontdoor_origin_fqdn_override           = var.cdn_frontdoor_origin_fqdn_override
   cdn_frontdoor_origin_host_header_override    = var.cdn_frontdoor_origin_host_header_override
   cdn_frontdoor_forwarding_protocol            = var.cdn_frontdoor_forwarding_protocol
+  enable_cdn_frontdoor_health_probe            = var.enable_cdn_frontdoor_health_probe
   key_vault_access_users                       = toset(var.key_vault_access_users)
   key_vault_access_ipv4                        = var.key_vault_access_ipv4
   tfvars_filename                              = var.tfvars_filename

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -138,6 +138,12 @@ variable "container_scale_http_concurrency" {
   default     = 10
 }
 
+variable "enable_cdn_frontdoor_health_probe" {
+  description = "Enable CDN Front Door health probe"
+  type        = bool
+  default     = false
+}
+
 variable "enable_dns_zone" {
   description = "Conditionally create a DNS zone"
   type        = bool


### PR DESCRIPTION
* Whilst the Origin is pointing to an App Gateway, Health Probes are failing. They aren't strictly necessary when we only have 1 origin so we can turn them off. Source: https://learn.microsoft.com/en-us/azure/frontdoor/health-probes\#disabling-health-probes

## Type of change
<!--- Tick the appropriate checkbox -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
