### PR TITLE
Remove SAS dependency for Data Protection blob access

### DIFF
--- a/Dfe.Academies.External.Web/Dfe.Academies.External.Web.csproj
+++ b/Dfe.Academies.External.Web/Dfe.Academies.External.Web.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.2" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Dfe.Academies.Contracts" Version="1.0.4" />
     <PackageReference Include="Dfe.Academisation.CorrelationIdMiddleware" Version="2.0.2" />
     <PackageReference Include="FluentValidation" Version="11.5.2" />

--- a/Dfe.Academies.External.Web/Dfe.Academies.External.Web.csproj
+++ b/Dfe.Academies.External.Web/Dfe.Academies.External.Web.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.2" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Dfe.Academies.Contracts" Version="1.0.4" />
     <PackageReference Include="Dfe.Academisation.CorrelationIdMiddleware" Version="2.0.2" />

--- a/Dfe.Academies.External.Web/Program.cs
+++ b/Dfe.Academies.External.Web/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System.Globalization;
-using Azure.Storage.Blobs;
+using Azure.Identity;
 using Dfe.Academies.External.Web.AutoMapper;
 using Dfe.Academies.External.Web.Extensions;
 using Dfe.Academies.External.Web.Factories;
@@ -231,12 +231,14 @@ var localDevelopment = builder.Configuration.GetValue<bool>("local_development")
 if (!localDevelopment)
 {
 	string blobName = "keys.xml";
-	BlobContainerClient container = new BlobContainerClient(new Uri(builder.Configuration["ConnectionStrings:BlobStorage"]));
-
-	BlobClient blobClient = container.GetBlobClient(blobName);
+	string blobContainerName = builder.Configuration["StorageAccount:ContainerName"];
+	Uri blobAccountUri = new Uri(builder.Configuration["StorageAccount:Uri"] + "/" + blobContainerName + "/" + blobName);
 
 	builder.Services.AddDataProtection()
-		.PersistKeysToAzureBlobStorage(blobClient);
+		.PersistKeysToAzureBlobStorage(
+			blobAccountUri,
+			new DefaultAzureCredential()
+		);
 }
 
 builder.Services.AddQuartz(q => { q.UseMicrosoftDependencyInjectionJobFactory(); });

--- a/Dfe.Academies.External.Web/appsettings.json
+++ b/Dfe.Academies.External.Web/appsettings.json
@@ -46,6 +46,10 @@
 		"BlobStorage": "",
 		"RedisCache": ""
 	},
+	"StorageAccount" : {
+		"Uri": "",
+		"ContainerName": ""
+	},
 	"Google": {
 		"AnalyticsKey": "UA-140729870-2",
 		"TagManagerId": "GTM-59S3WZ4",


### PR DESCRIPTION
Using the overload for `PersistKeysToAzureBlobStorage` that accepts a `Uri` and a `Credential` means we shouldn't need to use a BlobClient or a SAS token to write the data protection keys into Azure Storage.