### PR TITLE
Add a Container Image label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY ./script/web-docker-entrypoint.sh /app/docker-entrypoint.sh
 # Stage 2
 ARG ASPNET_IMAGE_TAG
 FROM "mcr.microsoft.com/dotnet/aspnet:${ASPNET_IMAGE_TAG}" AS final
+LABEL org.opencontainers.image.source=https://github.com/DFE-Digital/Dfe.Academies.External
 
 COPY --from=build /app /app
 WORKDIR /app


### PR DESCRIPTION
GitHub would like us to include a Docker label when working with GitHub Packages

* https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images