### PR TITLE
Add ACR Import to buid-and-psuh workflow

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -113,9 +113,40 @@ jobs:
               core.setFailed(error.message);
             }
 
+  acr-import:
+    name: Import images to ${{ needs.set-env.outputs.environment }} ACR
+    needs: [ build-and-push-image, set-env ]
+    runs-on: ubuntu-22.04
+    if: needs.set-env.outputs.environment == 'development'
+    environment: ${{ needs.set-env.outputs.environment }}
+      - name: Azure login with ACA credentials
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.ACA_CREDENTIALS }}
+
+      - name: Run ACR Import
+        uses: azure/cli@v2
+        with:
+          azcliversion: 2.40.0
+          inlineScript: |
+            TAGS=(
+              ${{ needs.set-env.outputs.branch }}
+              ${{ needs.set-env.outputs.release }}
+              latest
+            )
+            az config set extension.use_dynamic_install=yes_without_prompt
+            for source in "${TAGS[@]}" do
+              az acr import \
+                --name ${{ secrets.ACR_NAME } \
+                --source "ghcr.io/${{ needs.set-env.outputs.github_repository_lc }}:$tag" \
+                --image "${{ env.DOCKER_IMAGE }}:$tag" \
+                --username ${{ github.actor }} \
+                --password ${{ secrets.GITHUB_TOKEN }}
+            done
+
   deploy-image:
     name: Deploy to ${{ needs.set-env.outputs.environment }} (${{ needs.set-env.outputs.release }})
-    needs: [ build-and-push-image, set-env ]
+    needs: [ build-and-push-image, set-env, acr-import ]
     runs-on: ubuntu-22.04
     environment: ${{ needs.set-env.outputs.environment }}
     steps:


### PR DESCRIPTION
* Once the image has been built and pushed to GHCR, the `acr-import` job will then trigger an `acr import` to the given environment `ACR_NAME`
* All tags will be imported (via the for loop, using the 3 tagged images)
* Currently this is restricted to just the 'development' environment for testing purposes.