### PR TITLE
Force acr import in workflow

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -143,7 +143,8 @@ jobs:
                 --source "ghcr.io/${{ needs.set-env.outputs.github_repository_lc }}:$tag" \
                 --image "${{ env.DOCKER_IMAGE }}:$tag" \
                 --username ${{ github.actor }} \
-                --password ${{ secrets.GITHUB_TOKEN }}
+                --password ${{ secrets.GITHUB_TOKEN }} \
+                --force
             done
 
   deploy-image:


### PR DESCRIPTION
* We are using import to update 'latest' and 'master' (for the branch name) tags. If the tag exists, we get the error:
  > tag already exists in target registry

  Setting `--force` will overwrite the tag