### PR TITLE
GitHub action deployment tweaks

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -57,8 +57,9 @@ jobs:
 
   create-tag:
     name: Tag and release
-    needs: set-env
+    needs: [ set-env, deploy-image ]
     runs-on: ubuntu-22.04
+    if: needs.set-env.outputs.environment == 'production'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -92,7 +93,7 @@ jobs:
       needs: [ deploy-image, set-env ]
       if: needs.set-env.outputs.environment == 'test' || needs.set-env.outputs.environment == 'development'
       environment: ${{ needs.set-env.outputs.environment }}
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       defaults:
         run:
           working-directory: Dfe.Academies.External.Web/CypressTests

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -25,24 +25,17 @@ jobs:
       environment: ${{ steps.var.outputs.environment }}
       branch: ${{ steps.var.outputs.branch }}
       release: ${{ steps.var.outputs.release }}
-      github_repository_lc: ${{ steps.var.outputs.github_repository_lc }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Get branch name for push/dispatch event
-        run: |
-          GIT_REF=${{ github.ref_name }}
-          echo "branch_ref=${GIT_REF}" >> $GITHUB_ENV
-
       - id: var
         run: |
-          GIT_REF=${{ env.branch_ref }}
+          GIT_REF=${{ github.ref_name }}
           GIT_BRANCH=${GIT_REF##*/}
           INPUT=${{ github.event.inputs.environment }}
           ENVIRONMENT=${INPUT:-"development"}
           RELEASE=${ENVIRONMENT,,}-`date +%Y-%m-%d`.${{ github.run_number }}
-          GITHUB_REPOSITORY=${{ github.repository }}
           echo "environment=${ENVIRONMENT,,}" >> $GITHUB_OUTPUT
           echo "branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
           echo "release=${RELEASE}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -23,7 +23,6 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       environment: ${{ steps.var.outputs.environment }}
-      branch: ${{ steps.var.outputs.branch }}
       release: ${{ steps.var.outputs.release }}
     steps:
       - name: Checkout
@@ -31,13 +30,10 @@ jobs:
 
       - id: var
         run: |
-          GIT_REF=${{ github.ref_name }}
-          GIT_BRANCH=${GIT_REF##*/}
           INPUT=${{ github.event.inputs.environment }}
           ENVIRONMENT=${INPUT:-"development"}
           RELEASE=${ENVIRONMENT,,}-`date +%Y-%m-%d`.${{ github.run_number }}
           echo "environment=${ENVIRONMENT,,}" >> $GITHUB_OUTPUT
-          echo "branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
           echo "release=${RELEASE}" >> $GITHUB_OUTPUT
 
   deploy-image:

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -77,11 +77,11 @@ jobs:
           script: |
             try {
               await github.rest.repos.createRelease({
-                draft: ${{ needs.set-env.outputs.environment == 'staging' }},
+                draft: false,
                 generate_release_notes: true,
                 name: "${{ needs.set-env.outputs.release }}",
                 owner: context.repo.owner,
-                prerelease: ${{ needs.set-env.outputs.environment == 'staging' }},
+                prerelease: false,
                 repo: context.repo.repo,
                 tag_name: "${{ needs.set-env.outputs.release }}",
               });

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -41,6 +41,7 @@ jobs:
           echo "release=${RELEASE}" >> $GITHUB_OUTPUT
 
   deploy-image:
+    name: Deploy
     needs: [ set-env ]
     uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v2.0.0
     with:


### PR DESCRIPTION
## Type of change
This is a change to the GitHub Action workflow that is responsible for deployments to Azure.

In an effort to reduce noise, I have turned off auto-tagging for Dev and Test environments.

I have also made it so the Tag for Production only gets created if the deployment is successful.