### PR TITLE
Add exclusion paths for build and test

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,9 +3,17 @@ name: .NET
 on:
   push:
     branches: [ master ]
+    paths:
+    - 'Dfe.Academies.*'
+    - '!Dfe.Academies.External.Web.CypressTests'
+    - '*.csproj'
   pull_request:
     branches: [ master ]
     types: [ opened, synchronize, reopened ]
+    paths:
+    - 'Dfe.Academies.*'
+    - '!Dfe.Academies.External.Web.CypressTests'
+    - '*.csproj'
 
 env:
   JAVA_VERSION: '17'


### PR DESCRIPTION
Sets paths to restrict when to run build and test.

This is to reduce the amount of times that sonarcloud is ran and to free up github runners