### PR TITLE
Toggleable Notification Banner

### DIFF
--- a/Dfe.Academies.External.Web/Pages/Shared/_Layout.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Shared/_Layout.cshtml
@@ -60,6 +60,7 @@
         document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>
 <partial name="_CookieConsentPartial"/>
+<partial name="_NotificationBanner"/>
 <partial name="_Header"/>
 
 

--- a/Dfe.Academies.External.Web/Pages/Shared/_NotificationBanner.cshtml
+++ b/Dfe.Academies.External.Web/Pages/Shared/_NotificationBanner.cshtml
@@ -1,0 +1,23 @@
+@inject IConfiguration _configuration
+
+@{
+    var notificationBannerMessage = _configuration["NotificationBannerMessage"] ?? string.Empty;
+}
+
+@if (!string.IsNullOrWhiteSpace(notificationBannerMessage))
+{
+    <div class="dfe-width-container">
+        <section class="govuk-notification-banner govuk-!-margin-bottom-0" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                    Important
+                </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <p>
+                    @notificationBannerMessage
+                </p>
+            </div>
+        </section>
+    </div>
+}

--- a/Dfe.Academies.External.Web/appsettings.json
+++ b/Dfe.Academies.External.Web/appsettings.json
@@ -73,6 +73,6 @@
 			"Application": "Dfe.Academies.External.Web"
 		}
 	},
-	"MaintenanceMode" : false
-
+	"MaintenanceMode" : false,
+	"NotificationBannerMessage": ""
 }


### PR DESCRIPTION
## Type of change
<!--- Tick the appropriate checkbox -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Expected behaviour
* By setting the value of 'NotificationBannerMessage' to a non-empty string, the govuk notification banner will be displayed above the header. This can be used for informing users of upcoming service changes or other important messages
