### PR TITLE
Set SKU tier for Redis

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -190,6 +190,7 @@ No resources.
 | <a name="input_key_vault_access_ipv4"></a> [key\_vault\_access\_ipv4](#input\_key\_vault\_access\_ipv4) | List of IPv4 Addresses that are permitted to access the Key Vault | `list(string)` | n/a | yes |
 | <a name="input_monitor_email_receivers"></a> [monitor\_email\_receivers](#input\_monitor\_email\_receivers) | A list of email addresses that should be notified by monitoring alerts | `list(string)` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
+| <a name="input_redis_cache_sku"></a> [redis\_cache\_sku](#input\_redis\_cache\_sku) | Redis Cache SKU | `string` | `"Basic"` | no |
 | <a name="input_registry_admin_enabled"></a> [registry\_admin\_enabled](#input\_registry\_admin\_enabled) | Do you want to enable access key based authentication for your Container Registry? | `bool` | `true` | no |
 | <a name="input_registry_managed_identity_assign_role"></a> [registry\_managed\_identity\_assign\_role](#input\_registry\_managed\_identity\_assign\_role) | Assign the 'AcrPull' Role to the Container App User-Assigned Managed Identity. Note: If you do not have 'Microsoft.Authorization/roleAssignments/write' permission, you will need to manually assign the 'AcrPull' Role to the identity | `bool` | `false` | no |
 | <a name="input_registry_server"></a> [registry\_server](#input\_registry\_server) | Container registry server | `string` | `""` | no |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -21,6 +21,7 @@ module "azure_container_apps_hosting" {
   container_scale_http_concurrency       = local.container_scale_http_concurrency
 
   enable_redis_cache = local.enable_redis_cache
+  redis_cache_sku    = local.redis_cache_sku
 
   enable_event_hub                          = local.enable_event_hub
   enable_logstash_consumer                  = local.enable_logstash_consumer

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -49,6 +49,7 @@ locals {
   existing_network_watcher_name                = var.existing_network_watcher_name
   existing_network_watcher_resource_group_name = var.existing_network_watcher_resource_group_name
   enable_redis_cache                           = var.enable_redis_cache
+  redis_cache_sku                              = var.redis_cache_sku
   statuscake_monitored_resource_addresses      = var.statuscake_monitored_resource_addresses
   statuscake_contact_group_name                = var.statuscake_contact_group_name
   statuscake_contact_group_integrations        = var.statuscake_contact_group_integrations

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -295,6 +295,12 @@ variable "enable_redis_cache" {
   type        = bool
 }
 
+variable "redis_cache_sku" {
+  description = "Redis Cache SKU"
+  type        = string
+  default     = "Basic"
+}
+
 variable "statuscake_api_token" {
   description = "API token for StatusCake"
   type        = string


### PR DESCRIPTION
This change allows us to override the default SKU selected for Redis Cache.
In Production we should change this from the default 'Basic' to 'Standard' so that we can leverage the 99.9% availability SLA