### PR TITLE
Switch to using a Service Principal for Terraform deployments

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -150,7 +150,11 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_azure_client_id"></a> [azure\_client\_id](#input\_azure\_client\_id) | Service Principal Client ID | `string` | n/a | yes |
+| <a name="input_azure_client_secret"></a> [azure\_client\_secret](#input\_azure\_client\_secret) | Service Principal Client Secret | `string` | n/a | yes |
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location in which to launch resources. | `string` | n/a | yes |
+| <a name="input_azure_subscription_id"></a> [azure\_subscription\_id](#input\_azure\_subscription\_id) | Service Principal Subscription ID | `string` | n/a | yes |
+| <a name="input_azure_tenant_id"></a> [azure\_tenant\_id](#input\_azure\_tenant\_id) | Service Principal Tenant ID | `string` | n/a | yes |
 | <a name="input_cdn_frontdoor_custom_domains"></a> [cdn\_frontdoor\_custom\_domains](#input\_cdn\_frontdoor\_custom\_domains) | Azure CDN Front Door custom domains. If they are within the DNS zone (optionally created), the Validation TXT records and ALIAS/CNAME records will be created | `list(string)` | n/a | yes |
 | <a name="input_cdn_frontdoor_enable_rate_limiting"></a> [cdn\_frontdoor\_enable\_rate\_limiting](#input\_cdn\_frontdoor\_enable\_rate\_limiting) | Enable CDN Front Door Rate Limiting. This will create a WAF policy, and CDN security policy. For pricing reasons, there will only be one WAF policy created. | `bool` | n/a | yes |
 | <a name="input_cdn_frontdoor_forwarding_protocol"></a> [cdn\_frontdoor\_forwarding\_protocol](#input\_cdn\_frontdoor\_forwarding\_protocol) | Azure CDN Front Door forwarding protocol | `string` | `"HttpsOnly"` | no |

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,3 +1,5 @@
 terraform {
-  backend "azurerm" {}
+  backend "azurerm" {
+    use_azuread_auth = true
+  }
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,6 +1,11 @@
 provider "azurerm" {
   features {}
   skip_provider_registration = true
+  storage_use_azuread        = true
+  client_id                  = var.azure_client_id
+  client_secret              = var.azure_client_secret
+  tenant_id                  = var.azure_tenant_id
+  subscription_id            = var.azure_subscription_id
 }
 
 provider "azapi" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,24 @@
+variable "azure_client_id" {
+  description = "Service Principal Client ID"
+  type        = string
+}
+
+variable "azure_client_secret" {
+  description = "Service Principal Client Secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "azure_tenant_id" {
+  description = "Service Principal Tenant ID"
+  type        = string
+}
+
+variable "azure_subscription_id" {
+  description = "Service Principal Subscription ID"
+  type        = string
+}
+
 variable "environment" {
   description = "Environment name. Will be used along with `project_name` as a prefix for all resources."
   type        = string


### PR DESCRIPTION
* This change modifies how deployments with Terraform are made. Previously we would login to Azure CLI using our own named @edu accounts and apply terraform changes using those accounts, however this is misaligned with our DfE would prefer us to run deployments.
* Instead, we ought to be using our subscription-specific deployment service principal. This service principal is granted the minimum role assignments that are required to deploy infrastructure.
* A big advantage to using the service principal approach is that we are able to conditionally deploy role assignments to managed identities which we were previously not able to achieve without intervention from DfE InfraOps. This helps free up bottlenecks in deployments and ensures we can bring up an entire service from cold without any role assignment issues.
* Another benefit to using our service principal as deployments are not tied to a specific person 