### PR TITLE
CVE-2024-21392

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ﻿# Stage 1
-ARG ASPNET_IMAGE_TAG=8.0.0-bookworm-slim
+ARG ASPNET_IMAGE_TAG=8.0-bookworm-slim
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /build
 


### PR DESCRIPTION
Tracking the 8.0.x tag allows us to capture upstream security updates from Microsoft