### PR TITLE
Configure HSTS settings for ASP.NET

### DIFF
--- a/Dfe.Academies.External.Web/Program.cs
+++ b/Dfe.Academies.External.Web/Program.cs
@@ -253,6 +253,15 @@ if (!localDevelopment)
 builder.Services.AddQuartz(q => { q.UseMicrosoftDependencyInjectionJobFactory(); });
 builder.Services.AddQuartzHostedService(opt => { opt.WaitForJobsToComplete = true; });
 
+// Enforce HTTPS in ASP.NET Core
+// @link https://learn.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?
+builder.Services.AddHsts(options =>
+{
+	options.Preload = true;
+	options.IncludeSubDomains = true;
+	options.MaxAge = TimeSpan.FromDays(365);
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -260,7 +269,6 @@ var app = builder.Build();
 if (!app.Environment.IsDevelopment())
 {
 	app.UseExceptionHandler("/Error");
-	// The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
 	app.UseHsts();
 }
 else


### PR DESCRIPTION
This PR simply adds the configuration overrides for the `useHsts()` method.
This allows us to set the `max-age` parameter to 365 days, and turn on `preload`