### PR TITLE
Ensure HSTS is set for requests behind a proxy

### DIFF
--- a/Dfe.Academies.External.Web/Program.cs
+++ b/Dfe.Academies.External.Web/Program.cs
@@ -315,15 +315,16 @@ app.MapControllers();
 app.UseSession();
 app.UseCookiePolicy();
 
-// culture
+// add OWASP top 10 response headers
+app.UseSecurityHeaders(SecureHeadersDefinitions.GetHeaderPolicyCollection());
+app.UseHsts();
+
+// Add Content-Language response header
 app.UseRequestLocalization(new RequestLocalizationOptions
 {
 	ApplyCurrentCultureToResponseHeaders = true
 });
 
-// add OWASP top 10 response headers
-app.UseSecurityHeaders(SecureHeadersDefinitions.GetHeaderPolicyCollection());
-app.UseHsts();
 app.UseMiddleware<CorrelationIdMiddleware>();
 
 // possible redis fix

--- a/Dfe.Academies.External.Web/Security/SecureHeadersDefinitions.cs
+++ b/Dfe.Academies.External.Web/Security/SecureHeadersDefinitions.cs
@@ -22,7 +22,7 @@ public static class SecureHeadersDefinitions
 	{
 		HeaderPolicyCollection policy = new HeaderPolicyCollection()
 			.AddFrameOptionsDeny()
-			.AddXssProtectionBlock()
+			.AddXssProtectionDisabled()
 			.AddContentTypeOptionsNoSniff()
 			.AddReferrerPolicyNoReferrer()
 			.RemoveServerHeader()


### PR DESCRIPTION
- Set Xss Protection to 0
- Set HSTS in all environments
- Ensure X-Forwarded headers are passed to dotnet 
