### PR TITLE
Scan the built docker image for CVEs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,4 +20,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           secrets: github_token=${{ secrets.GITHUB_TOKEN }}
+          cache-from: type=gha
+          cache-to: type=gha
           push: false

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,44 @@
+name: Docker test
+
+on:
+  push:
+    branches: master
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.build.outputs.imageid }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build docker image
+        uses: docker/build-push-action@v6
+        id: build
+        with:
+          secrets: github_token=${{ secrets.GITHUB_TOKEN }}
+          outputs: type=docker,dest=/tmp/${{ github.ref_name }}.tar
+          cache-from: type=gha
+          cache-to: type=gha
+          push: false
+
+      - name: Scan Docker image for CVEs
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          input: /tmp/${{ github.ref_name }}.tar
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          limit-severities-for-sarif: true
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload scan results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
When commits are pushed to `master`, build and scan the Docker image for CRITICAL or HIGH CVEs that are fixable, and push the results to the GitHub Security tab.