### PR TITLE
Set HTTP user agent header

### DIFF
--- a/Dfe.Academies.External.Web/Extensions/StartupExtensions.cs
+++ b/Dfe.Academies.External.Web/Extensions/StartupExtensions.cs
@@ -26,6 +26,7 @@ public static class StartupExtension
 			client.BaseAddress = new Uri(academiesApiEndpoint);
 			client.DefaultRequestHeaders.Add("ApiKey", academiesApiKey);
 			client.DefaultRequestHeaders.Add("ContentType", MediaTypeNames.Application.Json);
+			client.DefaultRequestHeaders.Add("User-Agent", "ApplyToBecome/1.0");
 		});
 	}
 
@@ -48,6 +49,7 @@ public static class StartupExtension
 			client.BaseAddress = new Uri(academisationApiEndpoint);
 			client.DefaultRequestHeaders.Add("x-api-key", academisationApiKey);
 			client.DefaultRequestHeaders.Add("ContentType", MediaTypeNames.Application.Json);
+			client.DefaultRequestHeaders.Add("User-Agent", "ApplyToBecome/1.0");
 		});
 	}
 


### PR DESCRIPTION
Set a custom User-Agent HTTP Header so that traffic can be segmented when running reports against the downstream APIs