### PR TITLE
Switch to Azure Linux base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,27 @@
-﻿# Stage 1
-ARG ASPNET_IMAGE_TAG=8.0-bookworm-slim
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+﻿# Set the major version of dotnet
+ARG DOTNET_VERSION=8.0
+
+# Stage 1 - Build the app using the dotnet SDK
+FROM "mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-azurelinux3.0" AS build
 WORKDIR /build
 
-ENV DEBIAN_FRONTEND=noninteractive
-
 COPY ./Dfe.Academies.External.Web/ ./Dfe.Academies.External.Web/
-
-RUN --mount=type=secret,id=github_token dotnet nuget add source --username USERNAME --password $(cat /run/secrets/github_token) --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"
-RUN dotnet restore Dfe.Academies.External.Web
-RUN dotnet build Dfe.Academies.External.Web --no-restore
-RUN dotnet publish Dfe.Academies.External.Web -c Release -o /app --no-restore
-
 COPY ./script/web-docker-entrypoint.sh /app/docker-entrypoint.sh
 
-# Stage 2
-ARG ASPNET_IMAGE_TAG
-FROM "mcr.microsoft.com/dotnet/aspnet:${ASPNET_IMAGE_TAG}" AS final
-LABEL org.opencontainers.image.source=https://github.com/DFE-Digital/Dfe.Academies.External
+# Mount GitHub Token as a Docker secret so that NuGet Feed can be accessed
+RUN --mount=type=secret,id=github_token dotnet nuget add source --username USERNAME --password $(cat /run/secrets/github_token) --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"
+
+# Restore, build and publish the dotnet solution
+RUN ["dotnet", "restore", "Dfe.Academies.External.Web"]
+RUN ["dotnet", "build", "Dfe.Academies.External.Web", "--no-restore", "-c", "Release"]
+RUN ["dotnet", "publish", "Dfe.Academies.External.Web", "--no-build", "-o", "/app"]
+
+# Stage 2 - Build a runtime environment
+FROM "mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-azurelinux3.0" AS final
+WORKDIR /app
+LABEL org.opencontainers.image.source="https://github.com/DFE-Digital/Dfe.Academies.External"
 
 COPY --from=build /app /app
-WORKDIR /app
-RUN chmod +x ./docker-entrypoint.sh
-ENV ASPNETCORE_HTTP_PORTS=80
-EXPOSE 80/tcp
+RUN ["chmod", "+x", "./docker-entrypoint.sh"]
+
+USER $APP_UID

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -171,6 +171,7 @@ No resources.
 | <a name="input_container_command"></a> [container\_command](#input\_container\_command) | Container command | `list(any)` | n/a | yes |
 | <a name="input_container_max_replicas"></a> [container\_max\_replicas](#input\_container\_max\_replicas) | Container max replicas | `number` | `2` | no |
 | <a name="input_container_min_replicas"></a> [container\_min\_replicas](#input\_container\_min\_replicas) | Container min replicas | `number` | `1` | no |
+| <a name="input_container_port"></a> [container\_port](#input\_container\_port) | Container port | `number` | `8080` | no |
 | <a name="input_container_scale_http_concurrency"></a> [container\_scale\_http\_concurrency](#input\_container\_scale\_http\_concurrency) | When the number of concurrent HTTP requests exceeds this value, then another replica is added. Replicas continue to add to the pool up to the max-replicas amount. | `number` | `10` | no |
 | <a name="input_container_secret_environment_variables"></a> [container\_secret\_environment\_variables](#input\_container\_secret\_environment\_variables) | Container secret environment variables | `map(string)` | n/a | yes |
 | <a name="input_create_container_app_blob_storage_sas"></a> [create\_container\_app\_blob\_storage\_sas](#input\_create\_container\_app\_blob\_storage\_sas) | Generate a SAS connection string that is exposed to your App as an environment variable so that it can connect to the Storage Account | `bool` | `false` | no |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -20,6 +20,7 @@ module "azure_container_apps_hosting" {
   container_min_replicas                 = local.container_min_replicas
   container_max_replicas                 = local.container_max_replicas
   container_scale_http_concurrency       = local.container_scale_http_concurrency
+  container_port                         = local.container_port
 
   enable_health_insights_api          = local.enable_health_insights_api
   health_insights_api_cors_origins    = local.health_insights_api_cors_origins

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -15,6 +15,7 @@ locals {
   container_secret_environment_variables          = var.container_secret_environment_variables
   container_min_replicas                          = var.container_min_replicas
   container_max_replicas                          = var.container_max_replicas
+  container_port                                  = var.container_port
   enable_cdn_frontdoor                            = var.enable_cdn_frontdoor
   enable_event_hub                                = var.enable_event_hub
   enable_logstash_consumer                        = var.enable_logstash_consumer

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -417,3 +417,9 @@ variable "cdn_frontdoor_vdp_destination_hostname" {
   type        = string
   default     = "vdp.security.education.gov.uk"
 }
+
+variable "container_port" {
+  description = "Container port"
+  type        = number
+  default     = 8080
+}


### PR DESCRIPTION
* Reduces the overall final image size by using Azure Linux
* Offers maximum compatibility with Azure infrastructure
* Uses arbitrary user instead of 'root'
* Supported by Microsoft

https://github.com/dotnet/dotnet-docker/blob/main/documentation/azurelinux.md#azure-linux

>[!WARNING]
>Note: ASP.NET Core apps (in official images) listen to [port 8080 by default⁠](https://github.com/dotnet/dotnet-docker/blob/6da64f31944bb16ecde5495b6a53fc170fbe100d/src/runtime-deps/8.0/bookworm-slim/amd64/Dockerfile#L7), starting with .NET 8. This is because it is using an arbitrary user. As a result we will need to update the Container App definition to list to Port 8080
