### PR TITLE
Auto re enable all accessibility checks

### DIFF
--- a/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewFAMApp.cy.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewFAMApp.cy.ts
@@ -88,7 +88,7 @@ describe('Create a FAM application', () => {
 
     application.addSchool()
 
-    cy.wait(2000).executeAccessibilityTests()
+    cy.executeAccessibilityTests()
 
     whatIsTheNameOfTheSchool.selectSchoolName('Plym')
    

--- a/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewFAMApp.cy.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewFAMApp.cy.ts
@@ -88,7 +88,7 @@ describe('Create a FAM application', () => {
 
     application.addSchool()
 
-    cy.executeAccessibilityTests()
+    cy.wait(2000).executeAccessibilityTests()
 
     whatIsTheNameOfTheSchool.selectSchoolName('Plym')
    

--- a/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewFAMApp.cy.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewFAMApp.cy.ts
@@ -88,13 +88,11 @@ describe('Create a FAM application', () => {
 
     application.addSchool()
 
-    // COMMENTED OUT - PLEASE SEE WORK ITEM 18999 - BUG: LIVE: Legacy A2B Accessibility Issues On JAM/FAM Name of school Page and JAM Name of Trust page
-    //cy.executeAccessibilityTests()
+    cy.executeAccessibilityTests()
 
     whatIsTheNameOfTheSchool.selectSchoolName('Plym')
    
-    // COMMENTED OUT - PLEASE SEE WORK ITEM 18999 - BUG: LIVE: Legacy A2B Accessibility Issues On JAM/FAM Name of school Page and JAM Name of Trust page
-    // cy.executeAccessibilityTests()
+    cy.executeAccessibilityTests()
 
     application.checkSchoolAdded()
       .selectFAMSchool()

--- a/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewJAMApp.cy.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewJAMApp.cy.ts
@@ -76,7 +76,7 @@ describe('Create a JAM application', () => {
 
     application.addTrust()
 
-    cy.wait(2000).executeAccessibilityTests()
+    cy.executeAccessibilityTests()
 
     whichTrustIsSchoolJoining.selectTrustName('Plym')
 
@@ -84,7 +84,7 @@ describe('Create a JAM application', () => {
 
     application.addSchool()
 
-    cy.wait(2000).executeAccessibilityTests()
+    cy.executeAccessibilityTests()
 
     whatIsTheNameOfTheSchool.selectSchoolName('Plym')
 

--- a/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewJAMApp.cy.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewJAMApp.cy.ts
@@ -76,22 +76,19 @@ describe('Create a JAM application', () => {
 
     application.addTrust()
 
-    // COMMENTED OUT - PLEASE SEE WORK ITEM 18999 - BUG: LIVE: Legacy A2B Accessibility Issues On JAM/FAM Name of school Page and JAM Name of Trust page
-    //cy.executeAccessibilityTests()
+    cy.executeAccessibilityTests()
 
     whichTrustIsSchoolJoining.selectTrustName('Plym')
 
-    // COMMENTED OUT - PLEASE SEE WORK ITEM 18999 - BUG: LIVE: Legacy A2B Accessibility Issues On JAM/FAM Name of school Page and JAM Name of Trust page
-    //cy.executeAccessibilityTests()
+    cy.executeAccessibilityTests()
 
     application.addSchool()
 
-    // COMMENTED OUT - PLEASE SEE WORK ITEM 18999 - BUG: LIVE: Legacy A2B Accessibility Issues On JAM/FAM Name of school Page and JAM Name of Trust page
-    //cy.executeAccessibilityTests()
+    cy.executeAccessibilityTests()
 
     whatIsTheNameOfTheSchool.selectSchoolName('Plym')
 
-    //cy.executeAccessibilityTests() - SEE COMMENT ABOVE ON LINE 87
+    cy.executeAccessibilityTests()
 
     application.selectTrustDetails()
 

--- a/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewJAMApp.cy.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewJAMApp.cy.ts
@@ -76,7 +76,7 @@ describe('Create a JAM application', () => {
 
     application.addTrust()
 
-    cy.executeAccessibilityTests()
+    cy.wait(2000).executeAccessibilityTests()
 
     whichTrustIsSchoolJoining.selectTrustName('Plym')
 
@@ -84,7 +84,7 @@ describe('Create a JAM application', () => {
 
     application.addSchool()
 
-    cy.executeAccessibilityTests()
+    cy.wait(2000).executeAccessibilityTests()
 
     whatIsTheNameOfTheSchool.selectSchoolName('Plym')
 

--- a/Dfe.Academies.External.Web/CypressTests/cypress/support/commands.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/support/commands.ts
@@ -6,6 +6,7 @@ Cypress.Commands.add('executeAccessibilityTests', () => {
   cy.checkA11y(
     null,
     {
+      retries: 3,
       runOnly: {
         type: 'tag',
         values: wcagStandards,


### PR DESCRIPTION
Re-enable accessibility checks and enable retries for aXe and A11y when elements are being redrawn initially throwing an accessibility violation in error
