### PR TITLE
Fixed Slack notification issues, added contributors, and deleted comm…

### DIFF
--- a/Dfe.Academies.External.Web/CypressTests/cypress.config.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     reporterEnabled: 'mochawesome',
     mochawesomeReporterOptions: {
       reportDir: 'cypress/reports/mocha', // added this for slack messaging plugin
-      quiet: true, // Fixed typo
+      quiet: true, 
       overwrite: false,
       html: false,
       json: true,

--- a/Dfe.Academies.External.Web/CypressTests/package.json
+++ b/Dfe.Academies.External.Web/CypressTests/package.json
@@ -7,6 +7,10 @@
     "cy:open": "cypress open --browser electron",
     "cy:run": "cypress run --browser electron",
     "cy:notify": "cypress-slack-reporter",
+    "clean:reports": "rm -rf cypress/reports/mocha/*.json",
+    "combine:reports": "mochawesome-merge  cypress/reports/mocha/*.json> mochareports/report.json",
+    "create:html:report": "marge  mochareports/report.json -f report -o mochareports",
+    "generate:html:report": "npm run combine:reports && npm run create:html:report",
     "lint": "eslint .",
     "generate:html:report": "mochawesome-merge ./cypress/reports/*.json > mochareports/report.json && mochawesome-report-generator mochareports/report.json"
   },

--- a/Dfe.Academies.External.Web/CypressTests/package.json
+++ b/Dfe.Academies.External.Web/CypressTests/package.json
@@ -5,9 +5,10 @@
   "main": "index.js",
   "scripts": {
     "cy:open": "cypress open --browser electron",
-    "cy:run": "cypress run --browser electron" ,
-    "cy:notify": "cypress-slack-reporter",
-    "lint": "eslint ."
+    "cy:run": "cypress run --browser electron",
+    "cy:notify": "node ./sendSlackNotification.js",
+    "lint": "eslint .",
+    "generate:html:report": "mochawesome-merge ./cypress/reports/*.json > mochareports/report.json && mochawesome-report-generator mochareports/report.json"
   },
   "keywords": [
     "regression",
@@ -20,7 +21,9 @@
   },
   "contributors": [
     "Dan Good",
-    "Chris Sherlock"
+    "Chris Sherlock",
+    "Fahad Darwish",
+    "Richika Dogra"
   ],
   "license": "ISC",
   "bugs": {
@@ -43,6 +46,7 @@
     "cypress-axe": "^1.4.0",
     "eslint": "^9.6.0",
     "eslint-plugin-cypress": "^3.0.0",
-    "zaproxy": "^2.0.0-rc.1"
+    "zaproxy": "^2.0.0-rc.1",
+    "cypress-multi-reporters": "^1.6.1"
   }
 }

--- a/Dfe.Academies.External.Web/CypressTests/package.json
+++ b/Dfe.Academies.External.Web/CypressTests/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "cy:open": "cypress open --browser electron",
     "cy:run": "cypress run --browser electron",
-    "cy:notify": "node ./sendSlackNotification.js",
+    "cy:notify": "cypress-slack-reporter",
     "lint": "eslint .",
     "generate:html:report": "mochawesome-merge ./cypress/reports/*.json > mochareports/report.json && mochawesome-report-generator mochareports/report.json"
   },


### PR DESCRIPTION
### **Description:**
This PR introduces improvements to the Cypress test setup and workflow, focusing on report generation and Slack integration for test notifications. The following changes have been implemented:

---

### **Key Changes:**

#### **1. Workflow File (`.github/workflows/cypress-tests.yml`):**
- **Removed redundant step:** `mkdir mochareports` is no longer necessary since the directory will be created dynamically by the report generator.
- **Improved Slack notifications:** Updated the `cy:notify` script to use a Node.js-based notification mechanism for more flexibility.

#### **2. Cypress Configuration (`Dfe.Academies.External.Web/CypressTests/cypress.config.ts`):**
- **Improved reporter setup:**
  - Added `mochawesomeReporterOptions` to define custom report directory paths and enable integration with Slack messaging.
  - Removed "Fixed a typo (`quiet` parameter added explicitly)."

#### **3. Package File (`Dfe.Academies.External.Web/CypressTests/package.json`):**
- **Scripts:**
  - Added a new script, `generate:html:report`, to merge JSON test results and generate an HTML report using `mochawesome-merge` and `mochawesome-report-generator`.
  - Updated `cy:notify` to utilise a Node.js-based Slack notification script (`sendSlackNotification.js`).
- **Dependencies:**
  - Added `cypress-multi-reporters` for improved reporting and integration with multiple tools.

---
### **Impact:**
- Simplifies report management by dynamically creating necessary directories.
- Improves Slack integration for test notifications with a customisable Node.js script.
- Aligns Cypress reporting with multi-reporter support for better integration with external tools.
- Adds recognition for new contributors to the project metadata.
