### PR TITLE
Test check conversion support grant banners no longer exist

### DIFF
--- a/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewFAMApp.cy.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewFAMApp.cy.ts
@@ -60,10 +60,20 @@ describe('Create a FAM application', () => {
 
   const trustOpeningYear = `${new Date().getFullYear() + 1}`
 
+  const home = {
+    warningIcon: () => cy.get('span[class="govuk-warning-text__icon"]'),
+    warningText: () => cy.get('strong[class="govuk-warning-text__text"]'),
+    start: () => cy.get('[data-cy="startNowButton"]').click()
+  }
+
   beforeEach(function () {
     cy.visit(Cypress.env('URL'))
 
     cookieHeaderModal.acceptAnalyticsCookies()
+
+    home.warningIcon().should('not.exist')
+
+    home.warningText().should('not.exist')
 
     home.start()
 

--- a/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewFAMApp.cy.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewFAMApp.cy.ts
@@ -60,10 +60,9 @@ describe('Create a FAM application', () => {
 
   const trustOpeningYear = `${new Date().getFullYear() + 1}`
 
-  const home = {
+  const homeAssertions = {
     warningIcon: () => cy.get('span[class="govuk-warning-text__icon"]'),
     warningText: () => cy.get('strong[class="govuk-warning-text__text"]'),
-    start: () => cy.get('[data-cy="startNowButton"]').click()
   }
 
   beforeEach(function () {
@@ -71,9 +70,9 @@ describe('Create a FAM application', () => {
 
     cookieHeaderModal.acceptAnalyticsCookies()
 
-    home.warningIcon().should('not.exist')
+    homeAssertions.warningIcon().should('not.exist')
 
-    home.warningText().should('not.exist')
+    homeAssertions.warningText().should('not.exist')
 
     home.start()
 
@@ -81,6 +80,15 @@ describe('Create a FAM application', () => {
   })
 
   it('should be able to create a new application', () => {
+  
+    const applicationAssertionCheck = {
+      applicationOverviewBanner: () => cy.get('.govuk-notification-banner')
+      
+    }
+
+    const famSchoolOverviewAssertionCheck = {
+      conversionSupportGrantLink: () => cy.contains('Conversion support grant')
+    }
     
     cy.executeAccessibilityTests()
 
@@ -96,6 +104,8 @@ describe('Create a FAM application', () => {
 
     cy.executeAccessibilityTests()
 
+    applicationAssertionCheck.applicationOverviewBanner().should('not.exist')
+
     application.addSchool()
 
     cy.executeAccessibilityTests()
@@ -108,6 +118,8 @@ describe('Create a FAM application', () => {
       .selectFAMSchool()
     
     cy.executeAccessibilityTests()
+
+    famSchoolOverviewAssertionCheck.conversionSupportGrantLink().should('not.exist')
 
     application.startAboutTheConversion()
 

--- a/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewJAMApp.cy.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewJAMApp.cy.ts
@@ -48,10 +48,9 @@ describe('Create a JAM application', () => {
   const chairName = `${faker.person.firstName()} ${faker.person.lastName()}`
   const chairEmail = faker.internet.email()
 
-  const home = {
+  const homeAssertions = {
     warningIcon: () => cy.get('span[class="govuk-warning-text__icon"]'),
     warningText: () => cy.get('strong[class="govuk-warning-text__text"]'),
-    start: () => cy.get('[data-cy="startNowButton"]').click()
   }
 
   beforeEach(function () {
@@ -59,9 +58,9 @@ describe('Create a JAM application', () => {
 
     cookieHeaderModal.acceptAnalyticsCookies()
 
-    home.warningIcon().should('not.exist')
+    homeAssertions.warningIcon().should('not.exist')
 
-    home.warningText().should('not.exist')
+    homeAssertions.warningText().should('not.exist')
 
     home.start()
 
@@ -69,6 +68,11 @@ describe('Create a JAM application', () => {
   })
 
   it('should be able to create a new application', () => {
+
+    const applicationAssertionCheck = {
+      applicationOverviewBanner: () => cy.get('.govuk-notification-banner'),
+      conversionSupportGrantLink: () => cy.contains('Conversion support grant')
+    }
 
     cy.executeAccessibilityTests()
 
@@ -83,6 +87,9 @@ describe('Create a JAM application', () => {
     whatIsYourRole.chooseRole('Governor')
 
     cy.executeAccessibilityTests()
+
+    applicationAssertionCheck.applicationOverviewBanner().should('not.exist')
+    applicationAssertionCheck.conversionSupportGrantLink().should('not.exist')
 
     application.addTrust()
 

--- a/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewJAMApp.cy.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/e2e/createNewJAMApp.cy.ts
@@ -48,10 +48,20 @@ describe('Create a JAM application', () => {
   const chairName = `${faker.person.firstName()} ${faker.person.lastName()}`
   const chairEmail = faker.internet.email()
 
+  const home = {
+    warningIcon: () => cy.get('span[class="govuk-warning-text__icon"]'),
+    warningText: () => cy.get('strong[class="govuk-warning-text__text"]'),
+    start: () => cy.get('[data-cy="startNowButton"]').click()
+  }
+
   beforeEach(function () {
     cy.visit(Cypress.env('URL'))
 
     cookieHeaderModal.acceptAnalyticsCookies()
+
+    home.warningIcon().should('not.exist')
+
+    home.warningText().should('not.exist')
 
     home.start()
 

--- a/Dfe.Academies.External.Web/CypressTests/cypress/e2e/deleteNewJAMApp.cy.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/e2e/deleteNewJAMApp.cy.ts
@@ -9,10 +9,9 @@ import confirmApplicationDelete from '../page-objects/pages/confirmApplicationDe
 
 describe('Delete application', () => {
 
-  const home = {
+  const homeAssertions = {
     warningIcon: () => cy.get('span[class="govuk-warning-text__icon"]'),
     warningText: () => cy.get('strong[class="govuk-warning-text__text"]'),
-    start: () => cy.get('[data-cy="startNowButton"]').click()
   }
 
   beforeEach(function () {
@@ -20,9 +19,9 @@ describe('Delete application', () => {
 
     cookieHeaderModal.acceptAnalyticsCookies()
 
-    home.warningIcon().should('not.exist')
+    homeAssertions.warningIcon().should('not.exist')
 
-    home.warningText().should('not.exist')
+    homeAssertions.warningText().should('not.exist')
 
     home.start()
 

--- a/Dfe.Academies.External.Web/CypressTests/cypress/e2e/deleteNewJAMApp.cy.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/e2e/deleteNewJAMApp.cy.ts
@@ -8,10 +8,21 @@ import application from '../page-objects/pages/application'
 import confirmApplicationDelete from '../page-objects/pages/confirmApplicationDelete'
 
 describe('Delete application', () => {
+
+  const home = {
+    warningIcon: () => cy.get('span[class="govuk-warning-text__icon"]'),
+    warningText: () => cy.get('strong[class="govuk-warning-text__text"]'),
+    start: () => cy.get('[data-cy="startNowButton"]').click()
+  }
+
   beforeEach(function () {
     cy.visit(Cypress.env('URL'))
 
     cookieHeaderModal.acceptAnalyticsCookies()
+
+    home.warningIcon().should('not.exist')
+
+    home.warningText().should('not.exist')
 
     home.start()
 

--- a/Dfe.Academies.External.Web/CypressTests/cypress/e2e/inviteAndRemoveContributor.cy.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/e2e/inviteAndRemoveContributor.cy.ts
@@ -12,10 +12,9 @@ describe('Invite/remove contributor', () => {
   const contributorEmail = faker.internet.email()
   const applicationId = '10280'
 
-  const home = {
+  const homeAssertions = {
     warningIcon: () => cy.get('span[class="govuk-warning-text__icon"]'),
     warningText: () => cy.get('strong[class="govuk-warning-text__text"]'),
-    start: () => cy.get('[data-cy="startNowButton"]').click()
   }
 
   beforeEach(function () {
@@ -23,9 +22,9 @@ describe('Invite/remove contributor', () => {
 
     cookieHeaderModal.acceptAnalyticsCookies()
 
-    home.warningIcon().should('not.exist')
+    homeAssertions.warningIcon().should('not.exist')
 
-    home.warningText().should('not.exist')
+    homeAssertions.warningText().should('not.exist')
 
     home.start()
 

--- a/Dfe.Academies.External.Web/CypressTests/cypress/e2e/inviteAndRemoveContributor.cy.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/e2e/inviteAndRemoveContributor.cy.ts
@@ -12,10 +12,20 @@ describe('Invite/remove contributor', () => {
   const contributorEmail = faker.internet.email()
   const applicationId = '10280'
 
+  const home = {
+    warningIcon: () => cy.get('span[class="govuk-warning-text__icon"]'),
+    warningText: () => cy.get('strong[class="govuk-warning-text__text"]'),
+    start: () => cy.get('[data-cy="startNowButton"]').click()
+  }
+
   beforeEach(function () {
     cy.visit(Cypress.env('URL'))
 
     cookieHeaderModal.acceptAnalyticsCookies()
+
+    home.warningIcon().should('not.exist')
+
+    home.warningText().should('not.exist')
 
     home.start()
 

--- a/Dfe.Academies.External.Web/CypressTests/cypress/page-objects/pages/application.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/page-objects/pages/application.ts
@@ -197,6 +197,12 @@ class Application {
 
     return this
   }
+
+  public applicationOverviewBanner(): this {
+    cy.get('div[class="govuk-notification-banner"]')
+
+    return this
+  }
 }
 
 const application = new Application()

--- a/Dfe.Academies.External.Web/CypressTests/cypress/page-objects/pages/home.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/page-objects/pages/home.ts
@@ -4,6 +4,18 @@ class Home {
 
     return this
   }
+
+  public warningIcon(): this {
+    cy.get('span[class="govuk-warning-text__icon"]')
+
+    return this
+  }
+
+  public warningText(): this {
+    cy.get('strong[class="govuk-warning-text__text"]')
+
+    return this
+  }
 }
 
 const home = new Home()

--- a/Dfe.Academies.External.Web/CypressTests/cypress/page-objects/pages/home.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/page-objects/pages/home.ts
@@ -5,17 +5,6 @@ class Home {
     return this
   }
 
-  public warningIcon(): this {
-    cy.get('span[class="govuk-warning-text__icon"]')
-
-    return this
-  }
-
-  public warningText(): this {
-    cy.get('strong[class="govuk-warning-text__text"]')
-
-    return this
-  }
 }
 
 const home = new Home()

--- a/Dfe.Academies.External.Web/CypressTests/cypress/page-objects/pages/preOpeningSupportGrantDetails.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/page-objects/pages/preOpeningSupportGrantDetails.ts
@@ -16,6 +16,18 @@ class PreopeningSupportGrantDetails {
 
     return this
   }
+
+  public warningIcon(): this {
+    cy.get('span[class="govuk-warning-text__icon"]')
+
+    return this
+  }
+
+  public warningText(): this {
+    cy.get('strong[class="govuk-warning-text__text"]')
+
+    return this
+  }
 }
 
 const preopeningSupportGrantDetails = new PreopeningSupportGrantDetails()

--- a/Dfe.Academies.External.Web/CypressTests/cypress/page-objects/pages/preOpeningSupportGrantDetails.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/page-objects/pages/preOpeningSupportGrantDetails.ts
@@ -17,17 +17,6 @@ class PreopeningSupportGrantDetails {
     return this
   }
 
-  public warningIcon(): this {
-    cy.get('span[class="govuk-warning-text__icon"]')
-
-    return this
-  }
-
-  public warningText(): this {
-    cy.get('strong[class="govuk-warning-text__text"]')
-
-    return this
-  }
 }
 
 const preopeningSupportGrantDetails = new PreopeningSupportGrantDetails()

--- a/Dfe.Academies.External.Web/CypressTests/cypress/page-objects/pages/preOpeningSupportGrantSummary.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/page-objects/pages/preOpeningSupportGrantSummary.ts
@@ -16,6 +16,18 @@ class PreOpeningSupportGrantSummary {
 
     return this
   }
+
+  public warningIcon(): this {
+    cy.get('span[class="govuk-warning-text__icon"]')
+
+    return this
+  }
+
+  public warningText(): this {
+    cy.get('strong[class="govuk-warning-text__text"]')
+
+    return this
+  }
 }
 
 const preOpeningSupportGrantSummary = new PreOpeningSupportGrantSummary()

--- a/Dfe.Academies.External.Web/CypressTests/cypress/page-objects/pages/preOpeningSupportGrantSummary.ts
+++ b/Dfe.Academies.External.Web/CypressTests/cypress/page-objects/pages/preOpeningSupportGrantSummary.ts
@@ -17,17 +17,6 @@ class PreOpeningSupportGrantSummary {
     return this
   }
 
-  public warningIcon(): this {
-    cy.get('span[class="govuk-warning-text__icon"]')
-
-    return this
-  }
-
-  public warningText(): this {
-    cy.get('strong[class="govuk-warning-text__text"]')
-
-    return this
-  }
 }
 
 const preOpeningSupportGrantSummary = new PreOpeningSupportGrantSummary()


### PR DESCRIPTION
Added negative tests for all spec files to check homepage banners no longer display post-midnight of the day of Friday 20th December 2024
Added negative tests to JAM and FAM journey spec files to check banners removed from Application overview page and that the Conversion support grant link no longer displays for new users (JAM/FAM journeys)