### PR TITLE
Register health route for app

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -2,7 +2,7 @@ name: Docker test
 
 on:
   push:
-    branches: master
+    branches: [ master ]
 
 jobs:
   scan:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   JAVA_VERSION: '17'
-  
+
 jobs:
   build:
 
@@ -28,8 +28,8 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
-    - name: Set up JDK 11
+        dotnet-version: 8.0.x
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
         java-version: ${{ env.JAVA_VERSION }}
@@ -45,7 +45,7 @@ jobs:
     - name: Install dotnet reportgenerator
       run: dotnet tool install --global dotnet-reportgenerator-globaltool
     - name: Add nuget package source
-      run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"      
+      run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"
     - name: Restore dependencies
       run: dotnet restore
     - name: Build, Test and Analyze
@@ -57,4 +57,4 @@ jobs:
         dotnet build --no-restore
         dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage"
         reportgenerator -reports:./**/coverage.cobertura.xml -targetdir:./CoverageReport -reporttypes:SonarQube
-        dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"  
+        dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/Dfe.Academies.External.Web/Program.cs
+++ b/Dfe.Academies.External.Web/Program.cs
@@ -271,6 +271,8 @@ namespace Dfe.Academies.External.Web
 				options.MaxAge = TimeSpan.FromDays(365);
 			});
 
+			builder.Services.AddHealthChecks();
+
 			var app = builder.Build();
 
 			// Configure the HTTP request pipeline.
@@ -338,6 +340,8 @@ namespace Dfe.Academies.External.Web
 
 			// possible redis fix
 			ThreadPool.SetMinThreads(400, 400);
+
+			app.UseHealthChecks("/health");
 
 			app.Run();
 		}


### PR DESCRIPTION
* Adds a new route /health which is where .NET will report on the status of the application. We can use this for HTTP Monitors