### PR TITLE
Enable overriding of health check routes used by infrastructure monitors

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -169,6 +169,7 @@ No resources.
 | <a name="input_container_app_file_share_mount_path"></a> [container\_app\_file\_share\_mount\_path](#input\_container\_app\_file\_share\_mount\_path) | A path inside your container where the File Share will be mounted to | `string` | `"/srv/app/storage"` | no |
 | <a name="input_container_apps_allow_ips_inbound"></a> [container\_apps\_allow\_ips\_inbound](#input\_container\_apps\_allow\_ips\_inbound) | Restricts access to the Container Apps by creating a network security group rule that only allow inbound traffic from the provided list of IPs | `list(string)` | `[]` | no |
 | <a name="input_container_command"></a> [container\_command](#input\_container\_command) | Container command | `list(any)` | n/a | yes |
+| <a name="input_container_health_probe_path"></a> [container\_health\_probe\_path](#input\_container\_health\_probe\_path) | Specifies the path that is used to determine the liveness of the Container | `string` | `"/"` | no |
 | <a name="input_container_max_replicas"></a> [container\_max\_replicas](#input\_container\_max\_replicas) | Container max replicas | `number` | `2` | no |
 | <a name="input_container_min_replicas"></a> [container\_min\_replicas](#input\_container\_min\_replicas) | Container min replicas | `number` | `1` | no |
 | <a name="input_container_port"></a> [container\_port](#input\_container\_port) | Container port | `number` | `8080` | no |
@@ -204,6 +205,7 @@ No resources.
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | Image name | `string` | n/a | yes |
 | <a name="input_key_vault_access_ipv4"></a> [key\_vault\_access\_ipv4](#input\_key\_vault\_access\_ipv4) | List of IPv4 Addresses that are permitted to access the Key Vault | `list(string)` | n/a | yes |
 | <a name="input_monitor_email_receivers"></a> [monitor\_email\_receivers](#input\_monitor\_email\_receivers) | A list of email addresses that should be notified by monitoring alerts | `list(string)` | n/a | yes |
+| <a name="input_monitor_endpoint_healthcheck"></a> [monitor\_endpoint\_healthcheck](#input\_monitor\_endpoint\_healthcheck) | Specify a route that should be monitored for a 200 OK status | `string` | `"/"` | no |
 | <a name="input_monitor_http_availability_fqdn"></a> [monitor\_http\_availability\_fqdn](#input\_monitor\_http\_availability\_fqdn) | Specify a FQDN to monitor for HTTP Availability. Leave unset to dynamically calculate the correct FQDN | `string` | `""` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_redis_cache_sku"></a> [redis\_cache\_sku](#input\_redis\_cache\_sku) | Redis Cache SKU | `string` | `"Basic"` | no |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -63,6 +63,8 @@ module "azure_container_apps_hosting" {
   existing_logic_app_workflow    = local.existing_logic_app_workflow
   enable_container_health_probe  = local.enable_container_health_probe
   monitor_http_availability_fqdn = local.monitor_http_availability_fqdn
+  container_health_probe_path    = local.container_health_probe_path
+  monitor_endpoint_healthcheck   = local.monitor_endpoint_healthcheck
 
   enable_container_app_blob_storage     = local.enable_container_app_blob_storage
   create_container_app_blob_storage_sas = local.create_container_app_blob_storage_sas

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -66,4 +66,6 @@ locals {
   enable_cdn_frontdoor_vdp_redirects              = var.enable_cdn_frontdoor_vdp_redirects
   cdn_frontdoor_vdp_destination_hostname          = var.cdn_frontdoor_vdp_destination_hostname
   monitor_http_availability_fqdn                  = var.monitor_http_availability_fqdn
+  container_health_probe_path                     = var.container_health_probe_path
+  monitor_endpoint_healthcheck                    = var.monitor_endpoint_healthcheck
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -440,3 +440,15 @@ variable "monitor_http_availability_fqdn" {
   type        = string
   default     = ""
 }
+
+variable "container_health_probe_path" {
+  description = "Specifies the path that is used to determine the liveness of the Container"
+  type        = string
+  default     = "/"
+}
+
+variable "monitor_endpoint_healthcheck" {
+  description = "Specify a route that should be monitored for a 200 OK status"
+  type        = string
+  default     = "/"
+}


### PR DESCRIPTION
* The default health check route is `/` but now that we have `/health` available in the Dev environment we might want to override these values.