### PR TITLE
Disable file upload until sharepoint connection restored

### DIFF
--- a/Dfe.Academies.External.Web/Pages/School/AdditionalDetails.cshtml
+++ b/Dfe.Academies.External.Web/Pages/School/AdditionalDetails.cshtml
@@ -412,7 +412,7 @@
            
 
 
-            <div class="govuk-form-group">
+            @* <div class="govuk-form-group">
 
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
                     The school's Governing Body must have passed a resolution to apply to convert to academy status.
@@ -453,7 +453,7 @@
 	FileNames = Model.ResolutionConsentFileNames
 }' />
                 <p class="govuk-body govuk-radios__conditional">The application cannot be submitted without this. You can carry on the application and come back to this later.</p>
-            </div>
+            </div> *@
 
              <fieldset class="govuk-fieldset" role="group">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">

--- a/Dfe.Academies.External.Web/Pages/School/FurtherInformationSummary.cshtml.cs
+++ b/Dfe.Academies.External.Web/Pages/School/FurtherInformationSummary.cshtml.cs
@@ -130,11 +130,11 @@ namespace Dfe.Academies.External.Web.Pages.School
 			
 			var fileNames = _fileUploadService.GetFiles(FileUploadConstants.TopLevelSchoolFolderName, EntityId.ToString(), ApplicationReference, FileUploadConstants.ResolutionConsentfilePrefixFieldName).Result;
 			
-			
-			FISheading.Sections.Add(new(
-				FurtherInformationSectionViewModel.Resolution,
-				fileNames.Any() ? fileNames.First() : QuestionAndAnswerConstants.NoInfoAnswer)
-			);
+			// Disabled until file upload is re-enabled
+			// FISheading.Sections.Add(new(
+			// 	FurtherInformationSectionViewModel.Resolution,
+			// 	fileNames.Any() ? fileNames.First() : QuestionAndAnswerConstants.NoInfoAnswer)
+			// );
 			
 			FISheading.Sections.Add(new(
 				FurtherInformationSectionViewModel.EqualitiesImpactAssessment,

--- a/Dfe.Academies.External.Web/Program.cs
+++ b/Dfe.Academies.External.Web/Program.cs
@@ -203,12 +203,15 @@ namespace Dfe.Academies.External.Web
 
 			builder.Services.AddScoped<ICorrelationContext, CorrelationContext>();
 
-			builder.Services.AddHttpClient<IFileUploadService, FileUploadService>(client =>
-			{
-				client.BaseAddress = new Uri(configuration["Sharepoint:ApiUrl"]);
-				client.DefaultRequestHeaders.Add("User-Agent", "ApplyToBecome/1.0");
-			})
-				.AddPolicyHandler(GetRetryPolicy());
+			// TEMPORARILY DISABLED: FileUploadService is disabled due to file store issues
+			// To re-enable, replace NoOpFileUploadService with FileUploadService below:
+			// builder.Services.AddHttpClient<IFileUploadService, FileUploadService>(client =>
+			// {
+			// 	client.BaseAddress = new Uri(configuration["Sharepoint:ApiUrl"]);
+			// 	client.DefaultRequestHeaders.Add("User-Agent", "ApplyToBecome/1.0");
+			// })
+			// 	.AddPolicyHandler(GetRetryPolicy());
+			builder.Services.AddScoped<IFileUploadService, NoOpFileUploadService>();
 
 			static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy()
 			{

--- a/Dfe.Academies.External.Web/Services/ConversionApplicationRetrievalService.cs
+++ b/Dfe.Academies.External.Web/Services/ConversionApplicationRetrievalService.cs
@@ -375,9 +375,9 @@ public sealed class ConversionApplicationRetrievalService : BaseService, IConver
 		var foundationConsentFileNames = _fileUploadService.GetFiles(FileUploadConstants.TopLevelSchoolFolderName, selectedSchool.EntityId.ToString(),  applicationReference, FileUploadConstants.FoundationConsentFilePrefixFieldName).Result ?? [];
 		var resolutionConsentFileNames = _fileUploadService.GetFiles(FileUploadConstants.TopLevelSchoolFolderName, selectedSchool.EntityId.ToString(),  applicationReference, FileUploadConstants.ResolutionConsentfilePrefixFieldName).Result ?? [];
 		if (!string.IsNullOrEmpty(selectedSchool?.TrustBenefitDetails) &&
-		    ((selectedSchool?.DioceseName == null) == (!dioceseFileNames.Any()) &&
-		     (selectedSchool?.FoundationTrustOrBodyName == null) == (!foundationConsentFileNames.Any())) &&
-		    resolutionConsentFileNames.Any())
+		    (selectedSchool?.DioceseName != null &&//== (!dioceseFileNames.Any()) &&
+		     selectedSchool?.FoundationTrustOrBodyName != null)) //== (!foundationConsentFileNames.Any())) &&
+		    // resolutionConsentFileNames.Any())
 			return Status.Completed;
 
 		if (!string.IsNullOrEmpty(selectedSchool?.TrustBenefitDetails) ||

--- a/Dfe.Academies.External.Web/Services/NoOpFileUploadService.cs
+++ b/Dfe.Academies.External.Web/Services/NoOpFileUploadService.cs
@@ -1,0 +1,41 @@
+namespace Dfe.Academies.External.Web.Services;
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// No-operation implementation of IFileUploadService for temporary use when file storage is unavailable.
+/// This service allows the application to function without SharePoint connectivity while appearing to succeed to the UI.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class NoOpFileUploadService : IFileUploadService
+{
+	private readonly ILogger<NoOpFileUploadService> _logger;
+
+	public NoOpFileUploadService(ILogger<NoOpFileUploadService> logger)
+	{
+		_logger = logger;
+	}
+
+	public Task<List<string>> GetFiles(string entityName, string recordId, string recordName, string fieldName)
+	{
+		_logger.LogWarning("NoOpFileUploadService.GetFiles called - returning empty list. File storage is temporarily disabled.");
+		return Task.FromResult(new List<string>());
+	}
+
+	public Task<string> UploadFile(string entity, string recordId, string recordName, string fieldName, IFormFile file)
+	{
+		_logger.LogWarning("NoOpFileUploadService.UploadFile called for file '{FileName}' - operation skipped. File storage is temporarily disabled.", file.FileName);
+		return Task.FromResult(string.Empty);
+	}
+
+	public Task DeleteFile(string entityName, string recordId, string recordName, string fieldName, string fileName)
+	{
+		_logger.LogWarning("NoOpFileUploadService.DeleteFile called for file '{FileName}' - operation skipped. File storage is temporarily disabled.", fileName);
+		return Task.CompletedTask;
+	}
+
+	public Task FixApplyingSchool(string appReference, string schoolEntityId)
+	{
+		_logger.LogWarning("NoOpFileUploadService.FixApplyingSchool called - operation skipped. File storage is temporarily disabled.");
+		return Task.CompletedTask;
+	}
+}


### PR DESCRIPTION
For ticket [#290428](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/290428)

Disables file upload via no-op until connection is restored.