### PR TITLE
Add maintenance banner for file upload

### DIFF
--- a/Dfe.Academies.External.Web/Pages/YourApplications.cshtml
+++ b/Dfe.Academies.External.Web/Pages/YourApplications.cshtml
@@ -3,6 +3,18 @@
 @{
     ViewData["Title"] = "Your applications";
 }
+<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Important
+        </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">
+            File upload is currently experiencing issues. You will not be able to upload files until this is resolved. Please contact the DfE if you need to submit any files as part of your application.
+        </p>
+    </div>
+</div>
 
  <div class="govuk-grid-column-two-thirds">
 


### PR DESCRIPTION
For ticket [#290428](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/290428)

Adds a maintenance banner to notify about file upload issues